### PR TITLE
refactoring to avoid circular import dependency b/w profile and cluster pkgs

### DIFF
--- a/cmd/cluster/update.go
+++ b/cmd/cluster/update.go
@@ -1,16 +1,12 @@
 package cluster
 
 import (
-	"context"
 	_ "embed"
 	"fmt"
-	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
 	"github.com/arlonproj/arlon/pkg/argocd"
 	"github.com/arlonproj/arlon/pkg/cluster"
-	"github.com/arlonproj/arlon/pkg/common"
-	"github.com/arlonproj/arlon/pkg/profile"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -39,30 +35,9 @@ func updateClusterCommand() *cobra.Command {
 			}
 			updateInArgoCd := !outputYaml
 			clusterName := args[0]
-			oldApp, err := appIf.Get(context.Background(),
-				&argoapp.ApplicationQuery{Name: &clusterName})
-			if err != nil {
-				return fmt.Errorf("failed to get argocd app: %s", err)
-			}
-			if clusterSpecName == "" {
-				clusterSpecName = oldApp.Annotations[common.ClusterSpecAnnotationKey]
-				if clusterSpecName == "" {
-					return fmt.Errorf("existing cluster root app is missing clusterspec annotation")
-				}
-			}
-			if profileName == "" {
-				profileName = oldApp.Annotations[common.ProfileAnnotationKey]
-				if profileName == "" {
-					return fmt.Errorf("existing cluster root app is missing profile annotation")
-				}
-			}
-			prof, err := profile.Get(config, profileName, arlonNs)
-			if err != nil {
-				return fmt.Errorf("failed to get profile: %s", err)
-			}
 			rootApp, err := cluster.Update(appIf, config, argocdNs, arlonNs,
-				clusterName, clusterSpecName, prof, updateInArgoCd,
-				config.Host, oldApp)
+				clusterName, clusterSpecName, profileName, updateInArgoCd,
+				config.Host)
 			if err != nil {
 				return fmt.Errorf("failed to update cluster: %s", err)
 			}

--- a/pkg/cluster/git.go
+++ b/pkg/cluster/git.go
@@ -1,21 +1,18 @@
 package cluster
 
 import (
-	"bytes"
 	"embed"
 	"fmt"
 	arlonv1 "github.com/arlonproj/arlon/api/v1"
 	"github.com/arlonproj/arlon/pkg/argocd"
 	"github.com/arlonproj/arlon/pkg/bundle"
 	"github.com/arlonproj/arlon/pkg/gitutils"
-	"github.com/arlonproj/arlon/pkg/log"
+	logpkg "github.com/arlonproj/arlon/pkg/log"
+	"github.com/arlonproj/arlon/pkg/profile"
 	gogit "github.com/go-git/go-git/v5"
-	"io"
-	"io/fs"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"path"
-	"strings"
 	"text/template"
 )
 
@@ -34,7 +31,7 @@ func DeployToGit(
 	basePath string,
 	prof *arlonv1.Profile,
 ) error {
-	log := log.GetLogger()
+	log := logpkg.GetLogger()
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to get kubernetes client: %s", err)
@@ -67,7 +64,7 @@ func DeployToGit(
 			return fmt.Errorf("failed to recursively delete cluster directory: %s", err)
 		}
 	}
-	err = CopyManifests(wt, content, ".", mgmtPath)
+	err = gitutils.CopyManifests(wt, content, ".", mgmtPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy embedded content: %s", err)
 	}
@@ -84,8 +81,8 @@ func DeployToGit(
 		}
 	} else {
 		// static profile: include bundles as individual Applications now
-		om := MakeOverridesMap(prof)
-		err = ProcessBundles(wt, clusterName, repoUrl, mgmtPath, workloadPath, bundles, om)
+		om := profile.MakeOverridesMap(prof)
+		err = gitutils.ProcessBundles(wt, clusterName, repoUrl, mgmtPath, workloadPath, bundles, om)
 		if err != nil {
 			return fmt.Errorf("failed to process bundles: %s", err)
 		}
@@ -112,88 +109,6 @@ func DeployToGit(
 }
 
 // -----------------------------------------------------------------------------
-
-func CopyManifests(wt *gogit.Worktree, fs embed.FS, root string, mgmtPath string) error {
-	log := log.GetLogger()
-	items, err := fs.ReadDir(root)
-	if err != nil {
-		return fmt.Errorf("failed to read embedded directory: %s", err)
-	}
-	for _, item := range items {
-		filePath := path.Join(root, item.Name())
-		if item.IsDir() {
-			if err := CopyManifests(wt, fs, filePath, mgmtPath); err != nil {
-				return err
-			}
-		} else {
-			src, err := fs.Open(filePath)
-			if err != nil {
-				return fmt.Errorf("failed to open embedded file %s: %s", filePath, err)
-			}
-			// remove manifests/ prefix
-			components := strings.Split(filePath, "/")
-			dstPath := path.Join(components[1:]...)
-			dstPath = path.Join(mgmtPath, dstPath)
-			dst, err := wt.Filesystem.Create(dstPath)
-			if err != nil {
-				_ = src.Close()
-				return fmt.Errorf("failed to create destination file %s: %s", dstPath, err)
-			}
-			_, err = io.Copy(dst, src)
-			_ = src.Close()
-			_ = dst.Close()
-			if err != nil {
-				return fmt.Errorf("failed to copy embedded file: %s", err)
-			}
-			log.V(1).Info("copied embedded file", "destination", dstPath)
-		}
-	}
-	return nil
-}
-
-// -----------------------------------------------------------------------------
-
-const appTmpl = `
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: {{.AppName}}
-  namespace: {{.AppNamespace}}
-  finalizers:
-  # This solves issue #17
-  - resources-finalizer.argocd.argoproj.io/foreground
-spec:
-  syncPolicy:
-    automated:
-      prune: true
-  destination:
-    name: {{.ClusterName}}
-    namespace: {{.DestinationNamespace}}
-  project: default
-  source:
-    repoURL: {{.RepoUrl}}
-    path: {{.RepoPath}}
-    targetRevision: {{.RepoRevision}}
-{{- if eq .SrcType "helm" }}
-    helm:
-      parameters:
-      # Pass cluster name to the bundle in case it needs it and is a Helm chart.
-      # Example: this is required by the CAPI cluster autoscaler.
-      # Use arlon prefix to avoid any conflicts with the bundle's own values.
-      - name: arlon.clusterName
-        value: {{.ClusterName}}
-	{{- range .Overrides }}
-      - name: {{ .Key }}
-        value: {{ .Value }}
-	{{- end }}
-{{- else if eq .SrcType "kustomize" }}
-    kustomize: {}
-{{- else if eq .SrcType "ksonnet" }}
-    ksonnet: {}
-{{- else if eq .SrcType "directory" }}
-    directory: {}
-{{- end }}
-`
 
 // This is used for a dynamic profile, which is an Application containing
 // other Applications (one for each bundle), so the destination must always
@@ -228,23 +143,6 @@ spec:
         value: {{.AppName}}
 `
 
-type KVPair struct {
-	Key   string
-	Value string
-}
-
-type AppSettings struct {
-	AppName              string
-	ClusterName          string
-	RepoUrl              string
-	RepoPath             string
-	RepoRevision         string
-	SrcType              string
-	AppNamespace         string
-	DestinationNamespace string
-	Overrides            []KVPair
-}
-
 // -----------------------------------------------------------------------------
 
 func ProcessDynamicProfile(
@@ -261,7 +159,7 @@ func ProcessDynamicProfile(
 		return fmt.Errorf("failed to create app template: %s", err)
 	}
 	mgmtPath := path.Join(repoPath, "mgmt")
-	app := AppSettings{
+	app := gitutils.AppSettings{
 		ClusterName:          clusterName,
 		AppName:              fmt.Sprintf("%s-profile-%s", clusterName, profileName),
 		AppNamespace:         argocdNs,
@@ -282,102 +180,3 @@ func ProcessDynamicProfile(
 }
 
 // -----------------------------------------------------------------------------
-
-type OverridesMap map[string][]KVPair
-
-func ProcessBundles(
-	wt *gogit.Worktree,
-	clusterName string,
-	repoUrl string,
-	mgmtPath string,
-	workloadPath string,
-	bundles []bundle.Bundle,
-	overrides OverridesMap,
-) error {
-	if len(bundles) == 0 {
-		return nil
-	}
-	tmpl, err := template.New("app").Parse(appTmpl)
-	if err != nil {
-		return fmt.Errorf("failed to create app template: %s", err)
-	}
-	for _, b := range bundles {
-		bundleFileName := fmt.Sprintf("%s.yaml", b.Name)
-		app := AppSettings{
-			ClusterName:          clusterName,
-			AppName:              fmt.Sprintf("%s-%s", clusterName, b.Name),
-			AppNamespace:         "argocd",
-			DestinationNamespace: "default", // FIXME: make configurable
-		}
-		if b.RepoRevision == "" {
-			app.RepoRevision = "HEAD"
-		} else {
-			app.RepoRevision = b.RepoRevision
-		}
-		if b.Data == nil {
-			// dynamic bundle
-			if b.RepoUrl == "" {
-				return fmt.Errorf("b %s is neither static nor dynamic type", b.Name)
-			}
-			app.RepoUrl = b.RepoUrl
-			app.RepoPath = b.RepoPath
-			app.SrcType = b.SrcType
-			o := overrides[b.Name]
-			if o != nil {
-				// Add overrides
-				for _, kv := range o {
-					app.Overrides = append(app.Overrides, kv)
-				}
-			}
-		} else if b.RepoUrl != "" {
-			return fmt.Errorf("b %s has both data and repoUrl set", b.Name)
-		} else {
-			// static bundle
-			dirPath := path.Join(workloadPath, b.Name)
-			err := wt.Filesystem.MkdirAll(dirPath, fs.ModeDir|0700)
-			if err != nil {
-				return fmt.Errorf("failed to create directory in working tree: %s", err)
-			}
-			bundlePath := path.Join(dirPath, bundleFileName)
-			dst, err := wt.Filesystem.Create(bundlePath)
-			if err != nil {
-				return fmt.Errorf("failed to create file in working tree: %s", err)
-			}
-			_, err = io.Copy(dst, bytes.NewReader(b.Data))
-			_ = dst.Close()
-			if err != nil {
-				return fmt.Errorf("failed to copy static b %s: %s", b.Name, err)
-			}
-			app.RepoUrl = repoUrl
-			app.RepoPath = path.Join(workloadPath, b.Name)
-		}
-		appPath := path.Join(mgmtPath, "templates", bundleFileName)
-		dst, err := wt.Filesystem.Create(appPath)
-		if err != nil {
-			return fmt.Errorf("failed to create application file %s: %s", appPath, err)
-		}
-		err = tmpl.Execute(dst, &app)
-		if err != nil {
-			dst.Close()
-			return fmt.Errorf("failed to render application template %s: %s", appPath, err)
-		}
-		dst.Close()
-	}
-	return nil
-}
-
-// -----------------------------------------------------------------------------
-
-func MakeOverridesMap(profile *arlonv1.Profile) (om OverridesMap) {
-	if len(profile.Spec.Overrides) == 0 {
-		return
-	}
-	om = make(OverridesMap)
-	for _, item := range profile.Spec.Overrides {
-		om[item.Bundle] = append(om[item.Bundle], KVPair{
-			Key:   item.Key,
-			Value: item.Value,
-		})
-	}
-	return
-}

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	arlonv1 "github.com/arlonproj/arlon/api/v1"
 	"github.com/arlonproj/arlon/pkg/clusterspec"
 	"github.com/arlonproj/arlon/pkg/common"
 	"github.com/arlonproj/arlon/pkg/profile"
@@ -14,79 +13,13 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-func Update2(
-	appIf argoapp.ApplicationServiceClient,
-	config *restclient.Config,
-	argocdNs,
-	arlonNs,
-	clusterName,
-	clusterSpecName string,
-	prof *arlonv1.Profile,
-	updateInArgoCd bool,
-	managementClusterUrl string,
-	oldApp *argoappv1.Application,
-) (*argoappv1.Application, error) {
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get kube client: %s", err)
-	}
-	corev1 := kubeClient.CoreV1()
-	configMapsApi := corev1.ConfigMaps(arlonNs)
-	clusterSpecCm, err := configMapsApi.Get(context.Background(), clusterSpecName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get clusterspec configmap: %s", err)
-	}
-	// Ensure subchart name (api, cloud, clustertype) hasn't changed
-	subchartName, err := clusterspec.SubchartName(clusterSpecCm)
-	helmParamName := fmt.Sprintf("tags.%s", subchartName)
-	found := false
-	for _, param := range oldApp.Spec.Source.Helm.Parameters {
-		found = param.Name == helmParamName && param.Value == "true"
-		if found {
-			break
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("the api provider, cloud provider, or cluster type cannot change")
-	}
-	repoUrl := oldApp.Spec.Source.RepoURL
-	repoBranch := oldApp.Spec.Source.TargetRevision
-	repoPath := oldApp.Spec.Source.Path
-	basePath, clstName, err := decomposePath(repoPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decompose repo path: %s", err)
-	}
-	if clstName != clusterName {
-		return nil, fmt.Errorf("unexpected cluster name extracted from repo path: %s",
-			clstName)
-	}
-	rootApp, err := ConstructRootApp(argocdNs, clusterName, repoUrl,
-		repoBranch, repoPath, clusterSpecName, clusterSpecCm, prof.Name,
-		managementClusterUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct root app: %s", err)
-	}
-	if oldApp.Spec.Source.RepoURL != rootApp.Spec.Source.RepoURL ||
-		oldApp.Spec.Source.Path != rootApp.Spec.Source.Path {
-		return nil, fmt.Errorf("git repo reference cannot change")
-	}
-	err = DeployToGit(config, argocdNs, arlonNs, clusterName,
-		repoUrl, repoBranch, basePath, prof)
-	if err != nil {
-		return nil, fmt.Errorf("failed to deploy git tree: %s", err)
-	}
-	if updateInArgoCd {
-		appUpdateRequest := argoapp.ApplicationUpdateRequest{
-			Application: rootApp,
-		}
-		_, err := appIf.Update(context.Background(), &appUpdateRequest)
-		if err != nil {
-			return nil, fmt.Errorf("failed to update ArgoCD root application: %s", err)
-		}
-	}
-	return rootApp, nil
-}
-
+// Update modifies a cluster to use a different cluster spec or profile,
+// or both. Only some specific changes are allowed. For example, the API
+// provider, cloud provider, or cluster type cannot change, meaning if a
+// new cluster spec is chosen, it must preserve those values.
+// There are no restrictions on the new profile, if one is specified.
+// Bundles associated with the old profile will automatically be removed from
+// the cluster.
 func Update(
 	appIf argoapp.ApplicationServiceClient,
 	config *restclient.Config,

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -7,12 +7,14 @@ import (
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	arlonv1 "github.com/arlonproj/arlon/api/v1"
 	"github.com/arlonproj/arlon/pkg/clusterspec"
+	"github.com/arlonproj/arlon/pkg/common"
+	"github.com/arlonproj/arlon/pkg/profile"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 )
 
-func Update(
+func Update2(
 	appIf argoapp.ApplicationServiceClient,
 	config *restclient.Config,
 	argocdNs,
@@ -24,6 +26,99 @@ func Update(
 	managementClusterUrl string,
 	oldApp *argoappv1.Application,
 ) (*argoappv1.Application, error) {
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kube client: %s", err)
+	}
+	corev1 := kubeClient.CoreV1()
+	configMapsApi := corev1.ConfigMaps(arlonNs)
+	clusterSpecCm, err := configMapsApi.Get(context.Background(), clusterSpecName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get clusterspec configmap: %s", err)
+	}
+	// Ensure subchart name (api, cloud, clustertype) hasn't changed
+	subchartName, err := clusterspec.SubchartName(clusterSpecCm)
+	helmParamName := fmt.Sprintf("tags.%s", subchartName)
+	found := false
+	for _, param := range oldApp.Spec.Source.Helm.Parameters {
+		found = param.Name == helmParamName && param.Value == "true"
+		if found {
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("the api provider, cloud provider, or cluster type cannot change")
+	}
+	repoUrl := oldApp.Spec.Source.RepoURL
+	repoBranch := oldApp.Spec.Source.TargetRevision
+	repoPath := oldApp.Spec.Source.Path
+	basePath, clstName, err := decomposePath(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompose repo path: %s", err)
+	}
+	if clstName != clusterName {
+		return nil, fmt.Errorf("unexpected cluster name extracted from repo path: %s",
+			clstName)
+	}
+	rootApp, err := ConstructRootApp(argocdNs, clusterName, repoUrl,
+		repoBranch, repoPath, clusterSpecName, clusterSpecCm, prof.Name,
+		managementClusterUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct root app: %s", err)
+	}
+	if oldApp.Spec.Source.RepoURL != rootApp.Spec.Source.RepoURL ||
+		oldApp.Spec.Source.Path != rootApp.Spec.Source.Path {
+		return nil, fmt.Errorf("git repo reference cannot change")
+	}
+	err = DeployToGit(config, argocdNs, arlonNs, clusterName,
+		repoUrl, repoBranch, basePath, prof)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy git tree: %s", err)
+	}
+	if updateInArgoCd {
+		appUpdateRequest := argoapp.ApplicationUpdateRequest{
+			Application: rootApp,
+		}
+		_, err := appIf.Update(context.Background(), &appUpdateRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update ArgoCD root application: %s", err)
+		}
+	}
+	return rootApp, nil
+}
+
+func Update(
+	appIf argoapp.ApplicationServiceClient,
+	config *restclient.Config,
+	argocdNs,
+	arlonNs,
+	clusterName,
+	clusterSpecName string,
+	profileName string,
+	updateInArgoCd bool,
+	managementClusterUrl string,
+) (*argoappv1.Application, error) {
+	oldApp, err := appIf.Get(context.Background(),
+		&argoapp.ApplicationQuery{Name: &clusterName})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get argocd app: %s", err)
+	}
+	if clusterSpecName == "" {
+		clusterSpecName = oldApp.Annotations[common.ClusterSpecAnnotationKey]
+		if clusterSpecName == "" {
+			return nil, fmt.Errorf("existing cluster root app is missing clusterspec annotation")
+		}
+	}
+	if profileName == "" {
+		profileName = oldApp.Annotations[common.ProfileAnnotationKey]
+		if profileName == "" {
+			return nil, fmt.Errorf("existing cluster root app is missing profile annotation")
+		}
+	}
+	prof, err := profile.Get(config, profileName, arlonNs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get profile: %s", err)
+	}
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kube client: %s", err)

--- a/pkg/common/kvpair.go
+++ b/pkg/common/kvpair.go
@@ -1,0 +1,8 @@
+package common
+
+type KVPair struct {
+	Key   string
+	Value string
+}
+
+type KVPairMap map[string][]KVPair

--- a/pkg/gitutils/bundles.go
+++ b/pkg/gitutils/bundles.go
@@ -1,0 +1,145 @@
+package gitutils
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/arlonproj/arlon/pkg/bundle"
+	"github.com/arlonproj/arlon/pkg/common"
+	gogit "github.com/go-git/go-git/v5"
+	"io"
+	"io/fs"
+	"path"
+	"text/template"
+)
+
+// -----------------------------------------------------------------------------
+
+const appTmpl = `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{.AppName}}
+  namespace: {{.AppNamespace}}
+  finalizers:
+  # This solves issue #17
+  - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+  destination:
+    name: {{.ClusterName}}
+    namespace: {{.DestinationNamespace}}
+  project: default
+  source:
+    repoURL: {{.RepoUrl}}
+    path: {{.RepoPath}}
+    targetRevision: {{.RepoRevision}}
+{{- if eq .SrcType "helm" }}
+    helm:
+      parameters:
+      # Pass cluster name to the bundle in case it needs it and is a Helm chart.
+      # Example: this is required by the CAPI cluster autoscaler.
+      # Use arlon prefix to avoid any conflicts with the bundle's own values.
+      - name: arlon.clusterName
+        value: {{.ClusterName}}
+	{{- range .Overrides }}
+      - name: {{ .Key }}
+        value: {{ .Value }}
+	{{- end }}
+{{- else if eq .SrcType "kustomize" }}
+    kustomize: {}
+{{- else if eq .SrcType "ksonnet" }}
+    ksonnet: {}
+{{- else if eq .SrcType "directory" }}
+    directory: {}
+{{- end }}
+`
+
+type AppSettings struct {
+	AppName              string
+	ClusterName          string
+	RepoUrl              string
+	RepoPath             string
+	RepoRevision         string
+	SrcType              string
+	AppNamespace         string
+	DestinationNamespace string
+	Overrides            []common.KVPair
+}
+
+func ProcessBundles(
+	wt *gogit.Worktree,
+	clusterName string,
+	repoUrl string,
+	mgmtPath string,
+	workloadPath string,
+	bundles []bundle.Bundle,
+	overrides common.KVPairMap,
+) error {
+	if len(bundles) == 0 {
+		return nil
+	}
+	tmpl, err := template.New("app").Parse(appTmpl)
+	if err != nil {
+		return fmt.Errorf("failed to create app template: %s", err)
+	}
+	for _, b := range bundles {
+		bundleFileName := fmt.Sprintf("%s.yaml", b.Name)
+		app := AppSettings{
+			ClusterName:          clusterName,
+			AppName:              fmt.Sprintf("%s-%s", clusterName, b.Name),
+			AppNamespace:         "argocd",
+			DestinationNamespace: "default", // FIXME: make configurable
+		}
+		if b.RepoRevision == "" {
+			app.RepoRevision = "HEAD"
+		} else {
+			app.RepoRevision = b.RepoRevision
+		}
+		if b.Data == nil {
+			// dynamic bundle
+			if b.RepoUrl == "" {
+				return fmt.Errorf("b %s is neither static nor dynamic type", b.Name)
+			}
+			app.RepoUrl = b.RepoUrl
+			app.RepoPath = b.RepoPath
+			app.SrcType = b.SrcType
+			o := overrides[b.Name]
+			app.Overrides = append(app.Overrides, o...)
+		} else if b.RepoUrl != "" {
+			return fmt.Errorf("b %s has both data and repoUrl set", b.Name)
+		} else {
+			// static bundle
+			dirPath := path.Join(workloadPath, b.Name)
+			err := wt.Filesystem.MkdirAll(dirPath, fs.ModeDir|0700)
+			if err != nil {
+				return fmt.Errorf("failed to create directory in working tree: %s", err)
+			}
+			bundlePath := path.Join(dirPath, bundleFileName)
+			dst, err := wt.Filesystem.Create(bundlePath)
+			if err != nil {
+				return fmt.Errorf("failed to create file in working tree: %s", err)
+			}
+			_, err = io.Copy(dst, bytes.NewReader(b.Data))
+			_ = dst.Close()
+			if err != nil {
+				return fmt.Errorf("failed to copy static b %s: %s", b.Name, err)
+			}
+			app.RepoUrl = repoUrl
+			app.RepoPath = path.Join(workloadPath, b.Name)
+		}
+		appPath := path.Join(mgmtPath, "templates", bundleFileName)
+		dst, err := wt.Filesystem.Create(appPath)
+		if err != nil {
+			return fmt.Errorf("failed to create application file %s: %s", appPath, err)
+		}
+		err = tmpl.Execute(dst, &app)
+		if err != nil {
+			dst.Close()
+			return fmt.Errorf("failed to render application template %s: %s", appPath, err)
+		}
+		dst.Close()
+	}
+	return nil
+}

--- a/pkg/gitutils/gitutils_test.go
+++ b/pkg/gitutils/gitutils_test.go
@@ -1,6 +1,7 @@
-package cluster
+package gitutils
 
 import (
+	"github.com/arlonproj/arlon/pkg/common"
 	"strings"
 	"testing"
 	"text/template"
@@ -50,7 +51,10 @@ func TestAppTemplate(t *testing.T) {
 		SrcType:              "helm",
 		AppNamespace:         "yyy",
 		DestinationNamespace: "zzz",
-		Overrides:            []KVPair{{"foo", "bar"}, {"goo", "gar"}},
+		Overrides: []common.KVPair{
+			{Key: "foo", Value: "bar"},
+			{Key: "goo", Value: "gar"},
+		},
 	}
 	tmpl, err := template.New("app").Parse(appTmpl)
 	if err != nil {

--- a/pkg/gitutils/manifests.go
+++ b/pkg/gitutils/manifests.go
@@ -1,0 +1,53 @@
+package gitutils
+
+import (
+	"embed"
+	"fmt"
+	"github.com/arlonproj/arlon/pkg/log"
+	gogit "github.com/go-git/go-git/v5"
+	"io"
+	"path"
+	"strings"
+)
+
+// -----------------------------------------------------------------------------
+
+func CopyManifests(wt *gogit.Worktree, fs embed.FS, root string, mgmtPath string) error {
+	log := log.GetLogger()
+	items, err := fs.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("failed to read embedded directory: %s", err)
+	}
+	for _, item := range items {
+		filePath := path.Join(root, item.Name())
+		if item.IsDir() {
+			if err := CopyManifests(wt, fs, filePath, mgmtPath); err != nil {
+				return err
+			}
+		} else {
+			src, err := fs.Open(filePath)
+			if err != nil {
+				return fmt.Errorf("failed to open embedded file %s: %s", filePath, err)
+			}
+			// remove manifests/ prefix
+			components := strings.Split(filePath, "/")
+			dstPath := path.Join(components[1:]...)
+			dstPath = path.Join(mgmtPath, dstPath)
+			dst, err := wt.Filesystem.Create(dstPath)
+			if err != nil {
+				_ = src.Close()
+				return fmt.Errorf("failed to create destination file %s: %s", dstPath, err)
+			}
+			_, err = io.Copy(dst, src)
+			_ = src.Close()
+			_ = dst.Close()
+			if err != nil {
+				return fmt.Errorf("failed to copy embedded file: %s", err)
+			}
+			log.V(1).Info("copied embedded file", "destination", dstPath)
+		}
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------


### PR DESCRIPTION
updateClusterCommand() and cluster.Update() were a mess after the overrides change. Attempting to move more of the logic back into cluster.Update() was impossible due to a circular dependency between the `profile` and `cluster` packages. This change is a major refactor to break this cycle. It results in many common operations refactored into `pkg/gitutils` and `pkg/common` packages. No new functionality, this is a pure refactor.