### PR TITLE
Backport : Update controller(s) to disable caching of ServiceAccount

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -46,8 +46,10 @@ func StartController(argocdConfigPath string, metricsAddr string, probeAddr stri
 		// in a particular namespace. Caching requires RBAC to be setup for
 		// cluster-wide List access, as opposed to the more secure
 		// namespace-scoped access.
+		// Update: need to do the same for ServiceAccount
 		ClientDisableCacheFor: []client.Object{
 			&corev1.Secret{},
+			&corev1.ServiceAccount{},
 		},
 	})
 	if err != nil {
@@ -102,6 +104,7 @@ func StartCallHomeController(metricsAddr string, probeAddr string, enableLeaderE
 		// namespace-scoped access.
 		ClientDisableCacheFor: []client.Object{
 			&corev1.Secret{},
+			&corev1.ServiceAccount{},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Backporting @bcle 's fix from main into v0.3 by cherry-picking. We recently saw this issue affecting a current deployment based on Arlon 0.3.0

The arlon controller now needs to read service accounts (a change
introduced with CallHomeConfig support).
RBAC is set up so that arlon can only read resources in its own
namespace. However, by default, the controller-runtime caching
system requires cluster-wide access, resulting in this kind of error
when reading a single service account:

E0617 00:44:42.645596       1 reflector.go:138]
pkg/mod/k8s.io/client-go@v0.22.2/tools/cache/reflector.go:167: Failed to
watch *v1.ServiceAccount: failed to list *v1.ServiceAccount:
serviceaccounts is forbidden: User "system:serviceaccount:arlon:default"
cannot list resource "serviceaccounts" in API group "" at the cluster
scope

This change disables caching for serviceaccounts. We already did this for secrets.
This issue appears intermittent, and only when CallHomeConfig is used
(CAS use case). That probably explains why it wasn't caught earlier.