### PR TITLE
Enable CI and Trivy GitHub action workflows on v0.3 branch too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - v0.3
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - v0.3
 
 jobs:
   build:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,10 +7,14 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - v0.3
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches:
+      - main
+      - v0.3
   schedule:
     - cron: '28 1 * * 0'
 


### PR DESCRIPTION
These workflows are currently enabled only on the main branch.