### PR TITLE
Add region validation for AWS in clusterspec create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/argoproj/gitops-engine v0.5.5 // indirect
 	github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0 // indirect
+	github.com/aws/aws-sdk-go v1.44.68 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bombsimon/logrusr v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.10.3 //v1.11 will upgrade k8s APIs to v0.23.x
 )
 
+require github.com/aws/aws-sdk-go v1.44.68
+
 require (
 	cloud.google.com/go v0.93.3 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -36,7 +38,6 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/argoproj/gitops-engine v0.5.5 // indirect
 	github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0 // indirect
-	github.com/aws/aws-sdk-go v1.44.68 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bombsimon/logrusr v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/argoproj/argo-cd/v2 v2.2.12
+	github.com/aws/aws-sdk-go v1.44.68
 	github.com/deckarep/golang-set v1.8.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
@@ -17,8 +18,6 @@ require (
 	sigs.k8s.io/cluster-api v1.0.5 //v1.1.0 will upgrade k8s APIs to v0.23.x
 	sigs.k8s.io/controller-runtime v0.10.3 //v1.11 will upgrade k8s APIs to v0.23.x
 )
-
-require github.com/aws/aws-sdk-go v1.44.68
 
 require (
 	cloud.google.com/go v0.93.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -616,6 +616,7 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.33.16/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.44.68 h1:7zNr5+HLG0TMq+ZcZ8KhT4eT2KyL7v+u7/jANKEIinM=
+github.com/aws/aws-sdk-go v1.44.68/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -1180,6 +1182,7 @@ golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR36ewZ4iGQIIrtnuCjFA=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/pkg/clusterspec/create.go
+++ b/pkg/clusterspec/create.go
@@ -33,6 +33,9 @@ func Create(
 	if err := ValidCloudProviderAndClusterType(cloudProvider, clusterType); err != nil {
 		return err
 	}
+	if err := ValidRegionByProvider(cloudProvider, region); err != nil {
+		return err
+	}
 	_, err := Get(kubeClient, arlonNs, specName)
 	if err == nil {
 		return fmt.Errorf("a clusterspec with that name already exists")

--- a/pkg/clusterspec/create.go
+++ b/pkg/clusterspec/create.go
@@ -33,7 +33,7 @@ func Create(
 	if err := ValidCloudProviderAndClusterType(cloudProvider, clusterType); err != nil {
 		return err
 	}
-	if err := ValidRegionByProvider(cloudProvider, region); err != nil {
+	if err := ValidateRegionByProvider(cloudProvider, region); err != nil {
 		return err
 	}
 	_, err := Get(kubeClient, arlonNs, specName)

--- a/pkg/clusterspec/utils.go
+++ b/pkg/clusterspec/utils.go
@@ -1,6 +1,15 @@
 package clusterspec
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+const (
+	aws   = "aws"
+	gcp   = "gcp"
+	azure = "azure"
+)
 
 var (
 	ValidApiProviders = map[string]bool{
@@ -8,18 +17,54 @@ var (
 		"xplane": true,
 	}
 	ValidCloudProviders = map[string]bool{
-		"aws":   true,
-		"gcp":   true,
-		"azure": true,
+		aws:   true,
+		gcp:   true,
+		azure: true,
 	}
 	ValidClusterTypesByCloud = map[string]map[string]bool{
-		"aws":   {"kubeadm": true, "eks": true},
-		"gcp":   {"kubeadm": true, "gke": true},
-		"azure": {"kubeadm": true, "aks": true},
+		aws:   {"kubeadm": true, "eks": true},
+		gcp:   {"kubeadm": true, "gke": true},
+		azure: {"kubeadm": true, "aks": true},
 	}
 	KubeconfigSecretKeyNameByApiProvider = map[string]string{
 		"capi":   "value",
 		"xplane": "kubeconfig",
+	}
+	// validRegionsAWS enumerates all the valid regions. This is obtained from the endpoint package of the AWS SDK
+	// https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/endpoints#pkg-constants
+	validRegionsAWS = []string{
+		endpoints.AfSouth1RegionID,
+		endpoints.ApEast1RegionID,
+		endpoints.ApNortheast1RegionID,
+		endpoints.ApNortheast2RegionID,
+		endpoints.ApNortheast3RegionID,
+		endpoints.ApSouth1RegionID,
+		endpoints.ApSoutheast1RegionID,
+		endpoints.ApSoutheast2RegionID,
+		endpoints.ApSoutheast3RegionID,
+		endpoints.CaCentral1RegionID,
+		endpoints.EuCentral1RegionID,
+		endpoints.EuNorth1RegionID,
+		endpoints.EuSouth1RegionID,
+		endpoints.EuWest1RegionID,
+		endpoints.EuWest2RegionID,
+		endpoints.EuWest3RegionID,
+		endpoints.MeSouth1RegionID,
+		endpoints.SaEast1RegionID,
+		endpoints.UsEast1RegionID,
+		endpoints.UsEast2RegionID,
+		endpoints.UsWest1RegionID,
+		endpoints.UsWest2RegionID,
+		endpoints.CnNorth1RegionID,
+		endpoints.CnNorthwest1RegionID,
+		endpoints.UsGovEast1RegionID,
+		endpoints.UsGovWest1RegionID,
+		endpoints.UsIsoEast1RegionID,
+		endpoints.UsIsoWest1RegionID,
+		endpoints.UsIsobEast1RegionID,
+	}
+	validRegionsByProvider = map[string][]string{
+		aws: validRegionsAWS,
 	}
 )
 
@@ -53,6 +98,26 @@ func ValidCloudProviderAndClusterType(cloudProvider string, clusterType string) 
 	if !ValidClusterTypesByCloud[cloudProvider][clusterType] {
 		return fmt.Errorf("invalid cluster type, the valid values are: %s",
 			ValidValues(ValidClusterTypesByCloud[cloudProvider]))
+	}
+	return nil
+}
+
+// isOneOf takes in a string value and a slice of all possible valid values for the string.
+// It returns true if the provided val is in possibleValues, false otherwise.
+func isOneOf(val string, possibleValues []string) bool {
+	for _, value := range possibleValues {
+		if val == value {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidRegionByProvider checks if a supplied region string is valid or not for the given provider.
+func ValidRegionByProvider(provider string, region string) error {
+	validRegions := validRegionsByProvider[provider]
+	if !isOneOf(region, validRegions) {
+		return fmt.Errorf("invalid region %s for %s, valid values are: %v", region, provider, validRegions)
 	}
 	return nil
 }

--- a/pkg/clusterspec/utils.go
+++ b/pkg/clusterspec/utils.go
@@ -113,8 +113,8 @@ func isOneOf(val string, possibleValues []string) bool {
 	return false
 }
 
-// ValidRegionByProvider checks if a supplied region string is valid or not for the given provider.
-func ValidRegionByProvider(provider string, region string) error {
+// ValidateRegionByProvider checks if a supplied region string is valid or not for the given provider.
+func ValidateRegionByProvider(provider string, region string) error {
 	validRegions := validRegionsByProvider[provider]
 	if !isOneOf(region, validRegions) {
 		return fmt.Errorf("invalid region %s for %s, valid values are: %v", region, provider, validRegions)


### PR DESCRIPTION
- add AWS endpoint dep
- add region validation for aws when running clusterspec create
- the region values are hardcoded constants in the `endpoint` package

Manual Testing:
Success case:
```bash
➜  arlon git:(private/Rohitrajak1807/region-val-aws) bin/arlon clusterspec create capi-eks-51 --api capi --cloud aws --type eks --kubeversion v1.22.9 --nodecount 2 --nodetype t2.medium --tags staging --desc "2 node eks for general purpose" --sshkey jayanth --region us-east-1
```
Failure case:
```bash
➜  arlon git:(private/Rohitrajak1807/region-val-aws) bin/arlon clusterspec create capi-eks-51 --api capi --cloud aws --type eks --kubeversion v1.22.9 --nodecount 2 --nodetype t2.medium --tags staging --desc "2 node eks for general purpose" --sshkey jayanth --region literally-mars
Error: invalid region literally-mars for aws, valid values are: [af-south-1 ap-east-1 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-south-1 ap-southeast-1 ap-southeast-2 ap-southeast-3 ca-central-1 eu-central-1 eu-north-1 eu-south-1 eu-west-1 eu-west-2 eu-west-3 me-south-1 sa-east-1 us-east-1 us-east-2 us-west-1 us-west-2 cn-north-1 cn-northwest-1 us-gov-east-1 us-gov-west-1 us-iso-east-1 us-iso-west-1 us-isob-east-1]
```