### PR TITLE
Create dependabot.yml GH action to enable updates with DependaBot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  


### PR DESCRIPTION
We had enabled dependabot alerts but not dependabot updates so far. 
Enable weekly updates to go modules with dependabot, so that we don't have to do the chore of checking for updates and running them, opening PRs ourselves manually (at least as frequently)