### PR TITLE
Chore: Update Dockerfile to use the latest golang 1.17 patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17.9 as builder
+FROM golang:1.17.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Upgrade to go 1.17.13 from 1.17.9 for security fixes. https://go.dev/doc/devel/release#go1.17.minor 