### PR TITLE
port to main: Fix installation of CRDs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ the destination file is named `/tmp/config`, it's important for the secret creat
   `kubectl -n arlon create secret generic argocd-creds --from-file /tmp/config`
 - Delete the temporary config file
 - Clone the arlon git repo and cd to its top directory
-- Create the `clusterregistrations` CRD: `kubectl apply -f config/crd/bases/core.arlon.io_clusterregistrations.yaml`
+- Create the CRDs: `kubectl apply -f config/crd/bases/`
 - Deploy the controller: `kubectl apply -f deploy/manifests/`
 - Ensure the controller eventually enters the Running state: `watch kubectl -n arlon get pod`
 


### PR DESCRIPTION
ClusterRegistrations is not the only CRD to apply now. We have CallHomeConfig and profiles now. And maybe more in future.
https://github.com/arlonproj/arlon/tree/main/config/crd/bases

Multiple people ran into this and the missing CRDs caused issues in their installation (@cre8minus1 and Mike Riggs reported it. Happened to me and @ShaunakJoshi1407 too)

Aha! Link: https://pf9.aha.io/features/ARLON-259