### PR TITLE
refactor unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ testbin/*
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/pkg/basecluster/errors.go
+++ b/pkg/basecluster/errors.go
@@ -1,6 +1,8 @@
 package basecluster
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	ErrMultipleManifests    = errors.New("multiple manifests found")
@@ -9,4 +11,6 @@ var (
 	ErrNoConfigurationsYaml = errors.New("configurations.yaml is missing")
 	ErrMultipleClusters     = errors.New("there are 2 or more clusters")
 	ErrNoClusterResource    = errors.New("no cluster resource found")
+	ErrBuilderFailedRun     = errors.New("builder failed to run")
+	ErrResourceHasNamespace = errors.New("resource has a namespace defined")
 )

--- a/pkg/basecluster/errors.go
+++ b/pkg/basecluster/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrNoClusterResource    = errors.New("no cluster resource found")
 	ErrBuilderFailedRun     = errors.New("builder failed to run")
 	ErrResourceHasNamespace = errors.New("resource has a namespace defined")
+	Err2orMoreClusters      = errors.New("there are 2 or more clusters")
 )

--- a/pkg/basecluster/prepare.go
+++ b/pkg/basecluster/prepare.go
@@ -44,7 +44,7 @@ func Prepare(fileName string, validateOnly bool) (clusterName string, modifiedYa
 		gvk := info.Object.GetObjectKind().GroupVersionKind()
 		if gvk.Kind == "Cluster" {
 			if clusterName != "" {
-				err = fmt.Errorf("there are 2 or more clusters")
+				err = Err2orMoreClusters
 				return
 			}
 			clusterName = info.Name

--- a/pkg/basecluster/validate.go
+++ b/pkg/basecluster/validate.go
@@ -21,14 +21,12 @@ func Validate(fileName string) (clusterName string, err error) {
 	res := bld.Unstructured().FilenameParam(false, &opts).Do()
 	infos, err := res.Infos()
 	if err != nil {
-		return "", fmt.Errorf("builder failed to run: %s", err)
+		return "", fmt.Errorf("%w: %s", ErrBuilderFailedRun, err)
 	}
 	for _, info := range infos {
 		gvk := info.Object.GetObjectKind().GroupVersionKind()
 		if info.Namespace != "" {
-			return "",
-				fmt.Errorf("resource %s of kind %s has a namespace defined",
-					info.Name, gvk.Kind)
+			return "", fmt.Errorf("%w: resource: %s, kind: %s", ErrResourceHasNamespace, info.Name, gvk.Kind)
 		}
 		if gvk.Kind == "Cluster" {
 			if clusterName != "" {


### PR DESCRIPTION
- Wrapping errors and checking with `errors.Is()`
- Declared some additional Err variables

Testing:
Manual (running `make test`)
```shell
➜  arlon git:(private/Rohitrajak1807/unit-tests) make test
/Users/rohitr/Documents/Repositories/arlon/bin/controller-gen "crd:trivialVersions=true,preserveUnknownFields=false" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/rohitr/Documents/Repositories/arlon/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
mkdir -p /Users/rohitr/Documents/Repositories/arlon/testbin
test -f /Users/rohitr/Documents/Repositories/arlon/testbin/setup-envtest.sh || curl -sSLo /Users/rohitr/Documents/Repositories/arlon/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
source /Users/rohitr/Documents/Repositories/arlon/testbin/setup-envtest.sh; export GOARCH=amd64; fetch_envtest_tools /Users/rohitr/Documents/Repositories/arlon/testbin; setup_envtest_env /Users/rohitr/Documents/Repositories/arlon/testbin; go test ./... -coverprofile cover.out
Using cached envtest tools from /Users/rohitr/Documents/Repositories/arlon/testbin
setting up env vars
?       github.com/arlonproj/arlon      [no test files]
?       github.com/arlonproj/arlon/api/v1       [no test files]
?       github.com/arlonproj/arlon/cmd/basecluster      [no test files]
?       github.com/arlonproj/arlon/cmd/bundle   [no test files]
?       github.com/arlonproj/arlon/cmd/callhomecontroller       [no test files]
?       github.com/arlonproj/arlon/cmd/cluster  [no test files]
?       github.com/arlonproj/arlon/cmd/clusterspec      [no test files]
?       github.com/arlonproj/arlon/cmd/controller       [no test files]
?       github.com/arlonproj/arlon/cmd/list_clusters    [no test files]
?       github.com/arlonproj/arlon/cmd/profile  [no test files]
?       github.com/arlonproj/arlon/cmd/webhook  [no test files]
ok      github.com/arlonproj/arlon/controllers  12.713s coverage: 0.0% of statements
?       github.com/arlonproj/arlon/pkg/argocd   [no test files]
ok      github.com/arlonproj/arlon/pkg/basecluster      0.057s  coverage: 62.6% of statements
?       github.com/arlonproj/arlon/pkg/bundle   [no test files]
?       github.com/arlonproj/arlon/pkg/cluster  [no test files]
?       github.com/arlonproj/arlon/pkg/clusterspec      [no test files]
?       github.com/arlonproj/arlon/pkg/common   [no test files]
?       github.com/arlonproj/arlon/pkg/controller       [no test files]
ok      github.com/arlonproj/arlon/pkg/gitutils 0.038s  coverage: 0.0% of statements
?       github.com/arlonproj/arlon/pkg/log      [no test files]
?       github.com/arlonproj/arlon/pkg/profile  [no test files]
?       github.com/arlonproj/arlon/pkg/webhook  [no test files]

```


PS: @bcle please feel free to check this out.