### PR TITLE
unit test framework for git operations

### DIFF
--- a/cmd/basecluster/preparegit.go
+++ b/cmd/basecluster/preparegit.go
@@ -3,8 +3,10 @@ package basecluster
 import (
 	"fmt"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/arlonproj/arlon/pkg/argocd"
 	bcl "github.com/arlonproj/arlon/pkg/basecluster"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -23,7 +25,15 @@ func prepareGitBaseClusterCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get k8s client config: %s", err)
 			}
-			clusterName, changed, err := bcl.PrepareGitDir(config, argocdNs,
+			kubeClient, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return fmt.Errorf("failed to get kubernetes client: %s", err)
+			}
+			creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
+			if err != nil {
+				return fmt.Errorf("failed to get repository credentials: %s", err)
+			}
+			clusterName, changed, err := bcl.PrepareGitDir(creds,
 				repoUrl, repoRevision, repoPath)
 			if err != nil {
 				return fmt.Errorf("git preparation failed: %s", err)

--- a/cmd/basecluster/preparegit.go
+++ b/cmd/basecluster/preparegit.go
@@ -6,7 +6,6 @@ import (
 	"github.com/arlonproj/arlon/pkg/argocd"
 	bcl "github.com/arlonproj/arlon/pkg/basecluster"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -25,11 +24,7 @@ func prepareGitBaseClusterCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get k8s client config: %s", err)
 			}
-			kubeClient, err := kubernetes.NewForConfig(config)
-			if err != nil {
-				return fmt.Errorf("failed to get kubernetes client: %s", err)
-			}
-			creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
+			_, creds, err := argocd.GetKubeclientAndRepoCreds(config, argocdNs, repoUrl)
 			if err != nil {
 				return fmt.Errorf("failed to get repository credentials: %s", err)
 			}

--- a/cmd/basecluster/validategit.go
+++ b/cmd/basecluster/validategit.go
@@ -6,7 +6,6 @@ import (
 	"github.com/arlonproj/arlon/pkg/argocd"
 	bcl "github.com/arlonproj/arlon/pkg/basecluster"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -25,11 +24,7 @@ func validateGitBaseClusterCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get k8s client config: %s", err)
 			}
-			kubeClient, err := kubernetes.NewForConfig(config)
-			if err != nil {
-				return fmt.Errorf("failed to get kubernetes client: %s", err)
-			}
-			creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
+			_, creds, err := argocd.GetKubeclientAndRepoCreds(config, argocdNs, repoUrl)
 			if err != nil {
 				return fmt.Errorf("failed to get repository credentials: %s", err)
 			}

--- a/cmd/basecluster/validategit.go
+++ b/cmd/basecluster/validategit.go
@@ -3,8 +3,10 @@ package basecluster
 import (
 	"fmt"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/arlonproj/arlon/pkg/argocd"
 	bcl "github.com/arlonproj/arlon/pkg/basecluster"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -23,8 +25,15 @@ func validateGitBaseClusterCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get k8s client config: %s", err)
 			}
-			clusterName, err := bcl.ValidateGitDir(config, argocdNs, repoUrl,
-				repoRevision, repoPath)
+			kubeClient, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return fmt.Errorf("failed to get kubernetes client: %s", err)
+			}
+			creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
+			if err != nil {
+				return fmt.Errorf("failed to get repository credentials: %s", err)
+			}
+			clusterName, err := bcl.ValidateGitDir(creds, repoUrl, repoRevision, repoPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
 )
@@ -42,11 +41,7 @@ func createClusterCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get k8s client config: %s", err)
 			}
-			kubeClient, err := kubernetes.NewForConfig(config)
-			if err != nil {
-				return fmt.Errorf("failed to get kubernetes client: %s", err)
-			}
-			creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, clusterRepoUrl)
+			_, creds, err := argocd.GetKubeclientAndRepoCreds(config, argocdNs, clusterRepoUrl)
 			if err != nil {
 				return fmt.Errorf("failed to get repository credentials: %s", err)
 			}

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
 )
@@ -41,8 +42,16 @@ func createClusterCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get k8s client config: %s", err)
 			}
+			kubeClient, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return fmt.Errorf("failed to get kubernetes client: %s", err)
+			}
+			creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, clusterRepoUrl)
+			if err != nil {
+				return fmt.Errorf("failed to get repository credentials: %s", err)
+			}
 			createInArgoCd := !outputYaml
-			baseClusterName, err := bcl.ValidateGitDir(config, argocdNs,
+			baseClusterName, err := bcl.ValidateGitDir(creds,
 				clusterRepoUrl, clusterRepoRevision, clusterRepoPath)
 			if err != nil {
 				return fmt.Errorf("failed to validate base cluster: %s", err)

--- a/pkg/argocd/repo.go
+++ b/pkg/argocd/repo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"os"
 	"strings"
 )
@@ -45,6 +46,28 @@ func CloneRepo(
 	})
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("failed to clone repository: %s", err)
+	}
+	return
+}
+
+// -----------------------------------------------------------------------------
+
+func GetKubeclientAndRepoCreds(
+	config *rest.Config,
+	argocdNs string,
+	repoUrl string,
+) (
+	kubeClient *kubernetes.Clientset,
+	creds *RepoCreds,
+	err error,
+) {
+	kubeClient, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get kubernetes client: %s", err)
+	}
+	creds, err = GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get repository credentials: %s", err)
 	}
 	return
 }

--- a/pkg/argocd/repo.go
+++ b/pkg/argocd/repo.go
@@ -20,17 +20,12 @@ type RepoCreds struct {
 
 // -----------------------------------------------------------------------------
 
-// Clones a git repo registered with argocd into a local repository
+// CloneRepo clones a git repo registered with argocd into a local repository
 func CloneRepo(
-	kubeClient *kubernetes.Clientset,
-	argocdNs string,
+	creds *RepoCreds,
 	repoUrl string,
 	repoBranch string,
 ) (repo *gogit.Repository, tmpDir string, auth *http.BasicAuth, err error) {
-	creds, err := getRepoCreds(kubeClient, argocdNs, repoUrl)
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("failed to get repository credentials: %s", err)
-	}
 	auth = &http.BasicAuth{
 		Username: creds.Username,
 		Password: creds.Password,
@@ -56,7 +51,7 @@ func CloneRepo(
 
 // -----------------------------------------------------------------------------
 
-func getRepoCreds(
+func GetRepoCredsFromArgoCd(
 	kubeClient *kubernetes.Clientset,
 	argocdNs string,
 	repoUrl string,

--- a/pkg/argocd/repo.go
+++ b/pkg/argocd/repo.go
@@ -67,7 +67,8 @@ func GetKubeclientAndRepoCreds(
 	}
 	creds, err = GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get repository credentials: %s", err)
+		return nil, nil,
+			fmt.Errorf("failed to get repository credentials from argocd: %s", err)
 	}
 	return
 }

--- a/pkg/basecluster/prepare.go
+++ b/pkg/basecluster/prepare.go
@@ -11,9 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	restclient "k8s.io/client-go/rest"
 	"os"
 	"path"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -96,18 +94,12 @@ type KustomizationTemplateParams struct {
 }
 
 func PrepareGitDir(
-	config *restclient.Config,
-	argocdNs string,
+	creds *argocd.RepoCreds,
 	repoUrl string,
 	repoRevision string,
 	repoPath string,
 ) (clusterName string, changed bool, err error) {
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return "", false, fmt.Errorf("failed to get kubernetes client: %s", err)
-	}
-	repo, tmpDir, auth, err := argocd.CloneRepo(kubeClient, argocdNs,
-		repoUrl, repoRevision)
+	repo, tmpDir, auth, err := argocd.CloneRepo(creds, repoUrl, repoRevision)
 	defer os.RemoveAll(tmpDir)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to clone repo: %s", err)

--- a/pkg/basecluster/preparegit_test.go
+++ b/pkg/basecluster/preparegit_test.go
@@ -2,7 +2,6 @@ package basecluster
 
 import (
 	"errors"
-	"fmt"
 	"github.com/arlonproj/arlon/pkg/argocd"
 	"github.com/arlonproj/arlon/pkg/gitutils"
 	gogit "github.com/go-git/go-git/v5"
@@ -17,12 +16,12 @@ func TestGitPreparation(t *testing.T) {
 	subdirName := "requires_prep"
 	repoRevision := "master"
 	_, srcGitDir := createFileSystemBasedRepo(t, subdirName)
-	fmt.Println(srcGitDir)
+	t.Log("repo dir:", srcGitDir)
 	creds := &argocd.RepoCreds{}
 	repoUrl := "file://" + srcGitDir
 	_, err := ValidateGitDir(creds, repoUrl, repoRevision, subdirName)
 	assert.Assert(t, errors.Is(err, ErrNoKustomizationYaml), "unexpected validation error: %s", err)
-	fmt.Println("got expected error:", err)
+	t.Log("got expected error:", err)
 	clustName, changed, err := PrepareGitDir(creds, repoUrl, repoRevision, subdirName)
 	assert.NilError(t, err, "failed to prepare git directory")
 	assert.Assert(t, changed, "git dir preparation resulted in no changes")
@@ -44,5 +43,6 @@ func createFileSystemBasedRepo(t *testing.T, subdirName string) (*gogit.Reposito
 	assert.NilError(t, err, "failed to get worktree")
 	changed, err := gitutils.CommitChanges(tmpDir, wt, "initial commit")
 	assert.Assert(t, changed, "unexpected changed status from CommitChanges()")
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
 	return repo, tmpDir
 }

--- a/pkg/basecluster/preparegit_test.go
+++ b/pkg/basecluster/preparegit_test.go
@@ -1,0 +1,48 @@
+package basecluster
+
+import (
+	"errors"
+	"fmt"
+	"github.com/arlonproj/arlon/pkg/argocd"
+	"github.com/arlonproj/arlon/pkg/gitutils"
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/otiai10/copy"
+	"gotest.tools/assert"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestGitPreparation(t *testing.T) {
+	subdirName := "requires_prep"
+	repoRevision := "master"
+	_, srcGitDir := createFileSystemBasedRepo(t, subdirName)
+	fmt.Println(srcGitDir)
+	creds := &argocd.RepoCreds{}
+	repoUrl := "file://" + srcGitDir
+	_, err := ValidateGitDir(creds, repoUrl, repoRevision, subdirName)
+	assert.Assert(t, errors.Is(err, ErrNoKustomizationYaml), "unexpected validation error: %s", err)
+	fmt.Println("got expected error:", err)
+	clustName, changed, err := PrepareGitDir(creds, repoUrl, repoRevision, subdirName)
+	assert.NilError(t, err, "failed to prepare git directory")
+	assert.Assert(t, changed, "git dir preparation resulted in no changes")
+	assert.Equal(t, clustName, "capi-quickstart", "unexpected cluster name: %s", clustName)
+	_, err = ValidateGitDir(creds, repoUrl, repoRevision, subdirName)
+	assert.NilError(t, err, "unexpected 2nd validation error: %s", err)
+}
+
+func createFileSystemBasedRepo(t *testing.T, subdirName string) (*gogit.Repository, string) {
+	srcDir := path.Join("testdata", subdirName)
+	tmpDir, err := os.MkdirTemp("", "arlon-unittest-")
+	assert.NilError(t, err)
+	repo, err := gogit.PlainInit(tmpDir, false)
+	assert.NilError(t, err, "failed to init git dir")
+	dstDir := path.Join(tmpDir, subdirName)
+	err = copy.Copy(srcDir, dstDir)
+	assert.NilError(t, err, "failed to copy directory")
+	wt, err := repo.Worktree()
+	assert.NilError(t, err, "failed to get worktree")
+	changed, err := gitutils.CommitChanges(tmpDir, wt, "initial commit")
+	assert.Assert(t, changed, "unexpected changed status from CommitChanges()")
+	return repo, tmpDir
+}

--- a/pkg/basecluster/preparegit_test/requires_prep/manifest.yaml
+++ b/pkg/basecluster/preparegit_test/requires_prep/manifest.yaml
@@ -1,0 +1,26 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: capi-quickstart
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: capi-quickstart-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AWSCluster
+    name: capi-quickstart
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSCluster
+metadata:
+  name: capi-quickstart
+  namespace: foo
+spec:
+  region: us-west-2
+  sshKeyName: dummy

--- a/pkg/basecluster/validate.go
+++ b/pkg/basecluster/validate.go
@@ -48,10 +48,10 @@ func ValidateGitDir(
 	repoPath string,
 ) (clusterName string, err error) {
 	repo, tmpDir, _, err := argocd.CloneRepo(creds, repoUrl, repoRevision)
-	defer os.RemoveAll(tmpDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to clone repo: %s", err)
 	}
+	defer os.RemoveAll(tmpDir)
 	wt, err := repo.Worktree()
 	if err != nil {
 		return "", fmt.Errorf("failed to get repo worktree: %s", err)

--- a/pkg/basecluster/validate.go
+++ b/pkg/basecluster/validate.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"github.com/arlonproj/arlon/pkg/argocd"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"os"
 	"path"
 )
@@ -44,18 +42,12 @@ func Validate(fileName string) (clusterName string, err error) {
 // -----------------------------------------------------------------------------
 
 func ValidateGitDir(
-	config *restclient.Config,
-	argocdNs string,
+	creds *argocd.RepoCreds,
 	repoUrl string,
 	repoRevision string,
 	repoPath string,
 ) (clusterName string, err error) {
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return "", fmt.Errorf("failed to get kubernetes client: %s", err)
-	}
-	repo, tmpDir, _, err := argocd.CloneRepo(kubeClient, argocdNs,
-		repoUrl, repoRevision)
+	repo, tmpDir, _, err := argocd.CloneRepo(creds, repoUrl, repoRevision)
 	defer os.RemoveAll(tmpDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to clone repo: %s", err)

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -79,7 +79,7 @@ func Create(
 		corev1 := kubeClient.CoreV1()
 		bundles, err := bundle.GetBundlesFromProfile(prof, corev1, arlonNs)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get repository credentials: %s", err)
+			return nil, fmt.Errorf("failed to get bundles from profile: %s", err)
 		}
 		err = DeployToGit(creds, argocdNs, bundles, clusterName,
 			repoUrl, repoBranch, basePath, prof)

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -6,6 +6,8 @@ import (
 	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	arlonv1 "github.com/arlonproj/arlon/api/v1"
+	"github.com/arlonproj/arlon/pkg/argocd"
+	"github.com/arlonproj/arlon/pkg/bundle"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +72,20 @@ func Create(
 	}
 	if clusterSpecName != "" {
 		// gen1 only: deploy cluster files to git
-		err = DeployToGit(config, argocdNs, arlonNs, clusterName,
+		kubeClient, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get kubernetes client: %s", err)
+		}
+		corev1 := kubeClient.CoreV1()
+		bundles, err := bundle.GetBundlesFromProfile(prof, corev1, arlonNs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get bundles: %s", err)
+		}
+		creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get repository credentials: %s", err)
+		}
+		err = DeployToGit(creds, argocdNs, bundles, clusterName,
 			repoUrl, repoBranch, basePath, prof)
 		if err != nil {
 			return nil, fmt.Errorf("failed to deploy git tree: %s", err)

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -72,16 +72,12 @@ func Create(
 	}
 	if clusterSpecName != "" {
 		// gen1 only: deploy cluster files to git
-		kubeClient, err = kubernetes.NewForConfig(config)
+		creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get kubernetes client: %s", err)
+			return nil, fmt.Errorf("failed to get repo credentials: %s", err)
 		}
 		corev1 := kubeClient.CoreV1()
 		bundles, err := bundle.GetBundlesFromProfile(prof, corev1, arlonNs)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get bundles: %s", err)
-		}
-		creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get repository credentials: %s", err)
 		}

--- a/pkg/cluster/git.go
+++ b/pkg/cluster/git.go
@@ -10,8 +10,6 @@ import (
 	logpkg "github.com/arlonproj/arlon/pkg/log"
 	"github.com/arlonproj/arlon/pkg/profile"
 	gogit "github.com/go-git/go-git/v5"
-	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"path"
 	"text/template"
 )
@@ -22,9 +20,9 @@ var content embed.FS
 // -----------------------------------------------------------------------------
 
 func DeployToGit(
-	config *restclient.Config,
+	creds *argocd.RepoCreds,
 	argocdNs string,
-	arlonNs string,
+	bundles []bundle.Bundle,
 	clusterName string,
 	repoUrl string,
 	repoBranch string,
@@ -32,17 +30,7 @@ func DeployToGit(
 	prof *arlonv1.Profile,
 ) error {
 	log := logpkg.GetLogger()
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to get kubernetes client: %s", err)
-	}
-	corev1 := kubeClient.CoreV1()
-	bundles, err := bundle.GetBundlesFromProfile(prof, corev1, arlonNs)
-	if err != nil {
-		return fmt.Errorf("failed to get bundles: %s", err)
-	}
-	repo, tmpDir, auth, err := argocd.CloneRepo(kubeClient, argocdNs,
-		repoUrl, repoBranch)
+	repo, tmpDir, auth, err := argocd.CloneRepo(creds, repoUrl, repoBranch)
 	if err != nil {
 		return fmt.Errorf("failed to clone repo: %s", err)
 	}

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -98,10 +98,6 @@ func Update(
 		oldApp.Spec.Source.Path != rootApp.Spec.Source.Path {
 		return nil, fmt.Errorf("git repo reference cannot change")
 	}
-	kubeClient, err = kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get kubernetes client: %s", err)
-	}
 	bundles, err := bundle.GetBundlesFromProfile(prof, corev1, arlonNs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get bundles: %s", err)

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/arlonproj/arlon/pkg/argocd"
+	"github.com/arlonproj/arlon/pkg/bundle"
 	"github.com/arlonproj/arlon/pkg/clusterspec"
 	"github.com/arlonproj/arlon/pkg/common"
 	"github.com/arlonproj/arlon/pkg/profile"
@@ -96,7 +98,19 @@ func Update(
 		oldApp.Spec.Source.Path != rootApp.Spec.Source.Path {
 		return nil, fmt.Errorf("git repo reference cannot change")
 	}
-	err = DeployToGit(config, argocdNs, arlonNs, clusterName,
+	kubeClient, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubernetes client: %s", err)
+	}
+	bundles, err := bundle.GetBundlesFromProfile(prof, corev1, arlonNs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bundles: %s", err)
+	}
+	creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, repoUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repository credentials: %s", err)
+	}
+	err = DeployToGit(creds, argocdNs, bundles, clusterName,
 		repoUrl, repoBranch, basePath, prof)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy git tree: %s", err)

--- a/pkg/profile/git.go
+++ b/pkg/profile/git.go
@@ -10,7 +10,6 @@ import (
 	"github.com/arlonproj/arlon/pkg/gitutils"
 	"github.com/arlonproj/arlon/pkg/log"
 	gogit "github.com/go-git/go-git/v5"
-	"k8s.io/client-go/kubernetes"
 	"path"
 )
 
@@ -18,22 +17,16 @@ import (
 var content embed.FS
 
 func createInGit(
-	kubeClient *kubernetes.Clientset,
+	creds *argocd.RepoCreds,
 	profile *arlonv1.Profile,
-	argocdNs string,
 	arlonNs string,
+	bundles []bundle.Bundle,
 ) error {
 	log := log.GetLogger()
-	corev1 := kubeClient.CoreV1()
-	bundles, err := bundle.GetBundlesFromProfile(profile, corev1, arlonNs)
-	if err != nil {
-		return fmt.Errorf("failed to get bundles: %s", err)
-	}
 	repoUrl := profile.Spec.RepoUrl
 	repoPath := profile.Spec.RepoPath
 	repoRevision := profile.Spec.RepoRevision
-	repo, tmpDir, auth, err := argocd.CloneRepo(kubeClient, argocdNs,
-		repoUrl, repoRevision)
+	repo, tmpDir, auth, err := argocd.CloneRepo(creds, repoUrl, repoRevision)
 	if err != nil {
 		return fmt.Errorf("failed to clone repo: %s", err)
 	}

--- a/pkg/profile/update.go
+++ b/pkg/profile/update.go
@@ -92,7 +92,7 @@ func Update(
 		// Dynamic profile needs updating in git
 		kubeClient, creds, err := argocd.GetKubeclientAndRepoCreds(config, argocdNs, prof.Spec.RepoUrl)
 		if err != nil {
-			return false, fmt.Errorf("failed to get repository credentials: %s", err)
+			return false, fmt.Errorf("failed to get kubeclient and repository credentials: %s", err)
 		}
 		corev1 := kubeClient.CoreV1()
 		bndl, err := bundle.GetBundlesFromProfile(&prof.Profile, corev1, arlonNs)

--- a/pkg/profile/update.go
+++ b/pkg/profile/update.go
@@ -7,7 +7,6 @@ import (
 	"github.com/arlonproj/arlon/pkg/argocd"
 	"github.com/arlonproj/arlon/pkg/bundle"
 	"github.com/arlonproj/arlon/pkg/controller"
-	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -91,12 +90,7 @@ func Update(
 	}
 	if prof.Spec.RepoUrl != "" {
 		// Dynamic profile needs updating in git
-		var kubeClient *kubernetes.Clientset
-		kubeClient, err = kubernetes.NewForConfig(config)
-		if err != nil {
-			return false, fmt.Errorf("failed to get kube client: %s", err)
-		}
-		creds, err := argocd.GetRepoCredsFromArgoCd(kubeClient, argocdNs, prof.Spec.RepoUrl)
+		kubeClient, creds, err := argocd.GetKubeclientAndRepoCreds(config, argocdNs, prof.Spec.RepoUrl)
 		if err != nil {
 			return false, fmt.Errorf("failed to get repository credentials: %s", err)
 		}


### PR DESCRIPTION
I discovered that arlon's git operations can be unit tested without a git server, using `file://` type URLs. This allows us to put the source contents of a test case in a test directory, copy it to a temporary directory, initialize it as a repo, and use that as the repo target for an operation. This change includes
- The refactoring necessary to allow git operations to be unit tested. It mainly consists of separating out the logic for obtaining repo credentials from argocd, which are not needed in a unit test when using `file://` repo URLs.
- The actual test for git operations in the `basecluster` package, which include ValidateGitDir() and PrepareGitDir(). More tests will be added later for other packages.
- Testing: `go test ./pkg/basecluster`

Aha! Link: https://pf9.aha.io/features/ARLON-261