### PR TITLE
Misc. unit tests

### DIFF
--- a/pkg/bundle/common_test.go
+++ b/pkg/bundle/common_test.go
@@ -1,0 +1,46 @@
+package bundle
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestIsValidK8sName(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Desc     string
+		Expected bool
+	}{
+		{
+			Name:     "this-is-a-valid-k8s-name",
+			Desc:     "ValidName",
+			Expected: true,
+		},
+		{
+			Name:     "this-is-an-invalid-k8s-name+",
+			Desc:     "ContainsExtraSymbol",
+			Expected: false,
+		},
+		{
+			Name:     "THIS-Has-uppercase",
+			Desc:     "UppercaseName",
+			Expected: false,
+		},
+		{
+			Name:     "thisisaveryveryverylongk8swannabenamewhichistotallyinvalidandnotallowedthiswillreturnfalseandiamsureofit",
+			Desc:     "LongName",
+			Expected: false,
+		},
+		{
+			Name:     "gdrjnk+(gd",
+			Desc:     "LongName",
+			Expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			res := IsValidK8sName(tc.Name)
+			require.Equal(t, tc.Expected, res)
+		})
+	}
+}

--- a/pkg/bundle/common_test.go
+++ b/pkg/bundle/common_test.go
@@ -33,7 +33,7 @@ func TestIsValidK8sName(t *testing.T) {
 		},
 		{
 			Name:     "gdrjnk+(gd",
-			Desc:     "LongName",
+			Desc:     "InvalidChars",
 			Expected: false,
 		},
 	}

--- a/pkg/clusterspec/clusterspec.go
+++ b/pkg/clusterspec/clusterspec.go
@@ -71,8 +71,8 @@ func Get(
 	arlonNs string,
 	specName string,
 ) (cs *ClusterSpec, err error) {
-	corev1 := kubeClient.CoreV1()
-	configMapApi := corev1.ConfigMaps(arlonNs)
+	client := kubeClient.CoreV1()
+	configMapApi := client.ConfigMaps(arlonNs)
 	cm, err := configMapApi.Get(context.Background(), specName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/clusterspec/clusterspec_test.go
+++ b/pkg/clusterspec/clusterspec_test.go
@@ -1,0 +1,559 @@
+package clusterspec
+
+import (
+	"errors"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
+	"testing"
+)
+
+func TestFromConfigMap(t *testing.T) {
+	testCases := []struct {
+		Cm         *corev1.ConfigMap
+		Desc       string
+		ShouldFail bool
+	}{
+		{
+			Cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+					Labels: map[string]string{
+						"managed-by": "arlon",
+						"arlon-type": "clusterspec",
+					},
+				},
+				Data: map[string]string{
+					ApiProviderKey:               "apiProvider",
+					CloudProviderKey:             "cloudProvider",
+					ClusterTypeKey:               "clusterType",
+					KubernetesVersionKey:         "kubernetesVersion",
+					NodeTypeKey:                  "nodeType",
+					NodeCountKey:                 strconv.Itoa(3),
+					MasterNodeCountKey:           strconv.Itoa(1),
+					RegionKey:                    "region",
+					PodCidrBlockKey:              "podCidrBlock",
+					SshKeyNameKey:                "sshKeyName",
+					ClusterAutoscalerEnabledKey:  strconv.FormatBool(true),
+					ClusterAutoscalerMinNodesKey: strconv.Itoa(1),
+					ClusterAutoscalerMaxNodesKey: strconv.Itoa(9),
+					TagsKey:                      "tags",
+					DescriptionKey:               "description",
+				},
+			},
+			Desc:       "Valid config map",
+			ShouldFail: false,
+		},
+		{
+			Cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+					Labels: map[string]string{
+						"managed-by": "arlon",
+						"arlon-type": "clusterspec",
+					},
+				},
+				Data: map[string]string{
+					ApiProviderKey:               "apiProvider",
+					CloudProviderKey:             "cloudProvider",
+					ClusterTypeKey:               "clusterType",
+					KubernetesVersionKey:         "kubernetesVersion",
+					NodeTypeKey:                  "nodeType",
+					NodeCountKey:                 "invalidNodeCount",
+					MasterNodeCountKey:           strconv.Itoa(1),
+					RegionKey:                    "region",
+					PodCidrBlockKey:              "podCidrBlock",
+					SshKeyNameKey:                "sshKeyName",
+					ClusterAutoscalerEnabledKey:  strconv.FormatBool(true),
+					ClusterAutoscalerMinNodesKey: strconv.Itoa(1),
+					ClusterAutoscalerMaxNodesKey: strconv.Itoa(9),
+					TagsKey:                      "tags",
+					DescriptionKey:               "description",
+				},
+			},
+			Desc:       "Invalid config map",
+			ShouldFail: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			_, err := FromConfigMap(tc.Cm)
+			if tc.ShouldFail {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+		})
+	}
+
+	defaultResetCase := struct {
+		Cm   *corev1.ConfigMap
+		Desc string
+	}{
+		Cm: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+				Labels: map[string]string{
+					"managed-by": "arlon",
+					"arlon-type": "clusterspec",
+				},
+			},
+			Data: map[string]string{
+				ApiProviderKey:               "apiProvider",
+				CloudProviderKey:             "cloudProvider",
+				ClusterTypeKey:               "clusterType",
+				KubernetesVersionKey:         "kubernetesVersion",
+				NodeTypeKey:                  "nodeType",
+				NodeCountKey:                 strconv.Itoa(3),
+				MasterNodeCountKey:           "invalid",
+				RegionKey:                    "region",
+				PodCidrBlockKey:              "podCidrBlock",
+				SshKeyNameKey:                "sshKeyName",
+				ClusterAutoscalerEnabledKey:  "noIdea",
+				ClusterAutoscalerMinNodesKey: "strconv.Itoa(1)",
+				ClusterAutoscalerMaxNodesKey: "strconv.Itoa(9)",
+				TagsKey:                      "tags",
+				DescriptionKey:               "description",
+			},
+		},
+		Desc: "Testing default values",
+	}
+	t.Run(defaultResetCase.Desc, func(t *testing.T) {
+		cs, err := FromConfigMap(defaultResetCase.Cm)
+		require.NoError(t, err)
+		require.Equal(t, defaultMasterNodeCount, cs.MasterNodeCount)
+		require.Equal(t, defaultClusterAutoscalerEnabled, cs.ClusterAutoscalerEnabled)
+		require.Equal(t, defaultClusterAutoscalerMinNodes, cs.ClusterAutoscalerMinNodes)
+		require.Equal(t, defaultClusterAutoscalerMaxNodes, cs.ClusterAutoscalerMaxNodes)
+	})
+}
+
+func TestToConfigMap(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		apiProvider               string
+		cloudProvider             string
+		clusterType               string
+		kubernetesVersion         string
+		nodeType                  string
+		nodeCount                 int
+		masterNodeCount           int
+		region                    string
+		podCidrBlock              string
+		sshKeyName                string
+		clusterAutoscalerEnabled  bool
+		clusterAutoscalerMinNodes int
+		clusterAutoscalerMaxNodes int
+		tags                      string
+		description               string
+	}{
+		{
+			name:                      "test1",
+			apiProvider:               "capi",
+			cloudProvider:             "aws",
+			clusterType:               "eks",
+			kubernetesVersion:         "1.22.33",
+			nodeType:                  "noIdea",
+			nodeCount:                 1,
+			masterNodeCount:           1,
+			region:                    "us-west-1",
+			podCidrBlock:              "192.168.0.0/24",
+			sshKeyName:                "ssh",
+			clusterAutoscalerEnabled:  false,
+			clusterAutoscalerMinNodes: 0,
+			clusterAutoscalerMaxNodes: 0,
+			tags:                      "unit-test",
+			description:               "unit-test",
+		},
+		{
+			name:                      "test2",
+			apiProvider:               "not-capi",
+			cloudProvider:             "not-aws",
+			clusterType:               "eks",
+			kubernetesVersion:         "1.22.33",
+			nodeType:                  "noIdea",
+			nodeCount:                 1,
+			masterNodeCount:           1,
+			region:                    "us-west-2",
+			podCidrBlock:              "192.168.0.0/22",
+			sshKeyName:                "ssh",
+			clusterAutoscalerEnabled:  false,
+			clusterAutoscalerMinNodes: 0,
+			clusterAutoscalerMaxNodes: 0,
+			tags:                      "unit-test",
+			description:               "unit-test",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cm := ToConfigMap(tc.name, tc.apiProvider, tc.cloudProvider, tc.clusterType, tc.kubernetesVersion, tc.nodeType, tc.nodeCount, tc.masterNodeCount, tc.region, tc.podCidrBlock, tc.sshKeyName, tc.clusterAutoscalerEnabled, tc.clusterAutoscalerMinNodes, tc.clusterAutoscalerMaxNodes, tc.tags, tc.description)
+			require.Equal(t, tc.name, cm.Name)
+			require.Equal(t, tc.apiProvider, cm.Data[ApiProviderKey])
+			require.Equal(t, tc.cloudProvider, cm.Data[CloudProviderKey])
+			require.Equal(t, tc.clusterType, cm.Data[ClusterTypeKey])
+			require.Equal(t, tc.kubernetesVersion, cm.Data[KubernetesVersionKey])
+			require.Equal(t, tc.nodeType, cm.Data[NodeTypeKey])
+			require.Equal(t, tc.region, cm.Data[RegionKey])
+			require.Equal(t, tc.podCidrBlock, cm.Data[PodCidrBlockKey])
+			require.Equal(t, tc.sshKeyName, cm.Data[SshKeyNameKey])
+			require.Equal(t, tc.tags, cm.Data[TagsKey])
+			require.Equal(t, tc.description, cm.Data[DescriptionKey])
+			nodeCount, err := strconv.Atoi(cm.Data[NodeCountKey])
+			require.NoError(t, err)
+			require.Equal(t, tc.nodeCount, nodeCount)
+			masterNodes, err := strconv.Atoi(cm.Data[MasterNodeCountKey])
+			require.NoError(t, err)
+			require.Equal(t, tc.masterNodeCount, masterNodes)
+			casEnabled, err := strconv.ParseBool(cm.Data[ClusterAutoscalerEnabledKey])
+			require.NoError(t, err)
+			require.Equal(t, tc.clusterAutoscalerEnabled, casEnabled)
+			casMin, err := strconv.Atoi(cm.Data[ClusterAutoscalerMinNodesKey])
+			require.NoError(t, err)
+			require.Equal(t, tc.clusterAutoscalerMinNodes, casMin)
+			casMax, err := strconv.Atoi(cm.Data[ClusterAutoscalerMaxNodesKey])
+			require.NoError(t, err)
+			require.Equal(t, tc.clusterAutoscalerMaxNodes, casMax)
+		})
+	}
+}
+
+func TestSubchartNameFromClusterSpec(t *testing.T) {
+	testCases := []struct {
+		Desc     string
+		Cspec    ClusterSpec
+		Expected string
+		Err      error
+	}{
+		{
+			Desc: "ValidSpecCAPIAWSEKS",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: aws,
+				Type:          "eks",
+			},
+			Expected: "capi-aws-eks",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecCAPIAWSKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: aws,
+				Type:          "kubeadm",
+			},
+			Expected: "capi-aws-kubeadm",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecCAPIGCPGKE",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: gcp,
+				Type:          "gke",
+			},
+			Expected: "capi-gcp-gke",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecCAPIGCPKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: gcp,
+				Type:          "kubeadm",
+			},
+			Expected: "capi-gcp-kubeadm",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecCAPIAZAKS",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: azure,
+				Type:          "aks",
+			},
+			Expected: "capi-azure-aks",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecCAPIAZKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: azure,
+				Type:          "kubeadm",
+			},
+			Expected: "capi-azure-kubeadm",
+			Err:      nil,
+		},
+
+		{
+			Desc: "ValidSpecXPAWSEKS",
+			Cspec: ClusterSpec{
+				ApiProvider:   xplane,
+				CloudProvider: aws,
+				Type:          "eks",
+			},
+			Expected: "xplane-aws-eks",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecXPAWSKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   xplane,
+				CloudProvider: aws,
+				Type:          "kubeadm",
+			},
+			Expected: "xplane-aws-kubeadm",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecXPGCPGKE",
+			Cspec: ClusterSpec{
+				ApiProvider:   xplane,
+				CloudProvider: gcp,
+				Type:          "gke",
+			},
+			Expected: "xplane-gcp-gke",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecXPGCPKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   xplane,
+				CloudProvider: gcp,
+				Type:          "kubeadm",
+			},
+			Expected: "xplane-gcp-kubeadm",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecXPAZAKS",
+			Cspec: ClusterSpec{
+				ApiProvider:   xplane,
+				CloudProvider: azure,
+				Type:          "aks",
+			},
+			Expected: "xplane-azure-aks",
+			Err:      nil,
+		},
+		{
+			Desc: "ValidSpecXPAZKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   xplane,
+				CloudProvider: azure,
+				Type:          "kubeadm",
+			},
+			Expected: "xplane-azure-kubeadm",
+			Err:      nil,
+		},
+		{
+			Desc: "InvalidSpecUnknownAZKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   "unknown",
+				CloudProvider: azure,
+				Type:          "kubeadm",
+			},
+			Expected: "",
+			Err:      ErrInvalidAPIProvider,
+		},
+		{
+			Desc: "InvalidSpecCAPIAZKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: "rain",
+				Type:          "kubeadm",
+			},
+			Expected: "",
+			Err:      ErrInvalidCloudProvider,
+		},
+		{
+			Desc: "InvalidSpecCAPIAZKubeadm",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: "rain",
+				Type:          "kubeadm",
+			},
+			Expected: "",
+			Err:      ErrInvalidCloudProvider,
+		},
+		{
+			Desc: "InvalidSpecCAPIAZNotACluster",
+			Cspec: ClusterSpec{
+				ApiProvider:   capi,
+				CloudProvider: azure,
+				Type:          "notacluster",
+			},
+			Expected: "",
+			Err:      errors.New("invalid cluster type, the valid values are: aks|kubeadm"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			name, err := SubchartNameFromClusterSpec(&tc.Cspec)
+			require.Equal(t, tc.Err, err)
+			require.Equal(t, tc.Expected, name)
+		})
+	}
+}
+
+func TestSubchartName(t *testing.T) {
+	testCases := []struct {
+		Cm       *corev1.ConfigMap
+		Desc     string
+		Expected string
+		Err      error
+	}{
+		{
+			Cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+					Labels: map[string]string{
+						"managed-by": "arlon",
+						"arlon-type": "clusterspec",
+					},
+				},
+				Data: map[string]string{
+					ApiProviderKey:   capi,
+					CloudProviderKey: azure,
+					ClusterTypeKey:   "kubeadm",
+					NodeCountKey:     "3",
+				},
+			},
+			Desc:     "CAPIAzKubeadm",
+			Expected: "capi-azure-kubeadm",
+			Err:      nil,
+		},
+		{
+			Cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+					Labels: map[string]string{
+						"managed-by": "arlon",
+						"arlon-type": "clusterspec",
+					},
+				},
+				Data: map[string]string{
+					ApiProviderKey:   capi,
+					CloudProviderKey: azure,
+					ClusterTypeKey:   "aks",
+					NodeCountKey:     "3",
+				},
+			},
+			Desc:     "CAPIAzAKS",
+			Expected: "capi-azure-aks",
+			Err:      nil,
+		},
+		{
+			Cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+					Labels: map[string]string{
+						"managed-by": "arlon",
+						"arlon-type": "clusterspec",
+					},
+				},
+				Data: map[string]string{
+					ApiProviderKey:   "what",
+					CloudProviderKey: azure,
+					ClusterTypeKey:   "kubeadm",
+					NodeCountKey:     "3",
+				},
+			},
+			Desc:     "WhatAzKubeadm",
+			Expected: "",
+			Err:      ErrInvalidAPIProvider,
+		},
+		{
+			Cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+					Labels: map[string]string{
+						"managed-by": "arlon",
+						"arlon-type": "clusterspec",
+					},
+				},
+				Data: map[string]string{
+					ApiProviderKey:   capi,
+					CloudProviderKey: "water",
+					ClusterTypeKey:   "kubeadm",
+					NodeCountKey:     "3",
+				},
+			},
+			Desc:     "CAPIWaterKubeadm",
+			Expected: "",
+			Err:      ErrInvalidCloudProvider,
+		},
+		{
+			Cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+					Labels: map[string]string{
+						"managed-by": "arlon",
+						"arlon-type": "clusterspec",
+					},
+				},
+				Data: map[string]string{
+					ApiProviderKey:   capi,
+					CloudProviderKey: azure,
+					ClusterTypeKey:   "not-kubeadm",
+					NodeCountKey:     "3",
+				},
+			},
+			Desc:     "CAPIAzNotKubeadm",
+			Expected: "",
+			Err:      errors.New("invalid cluster type, the valid values are: aks|kubeadm"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			name, err := SubchartName(tc.Cm)
+			require.Equal(t, tc.Err, err)
+			require.Equal(t, tc.Expected, name)
+		})
+	}
+}
+
+func TestClusterAutoscalerSubchartNameFromClusterSpec(t *testing.T) {
+	testCases := []struct {
+		Cs       ClusterSpec
+		Desc     string
+		Err      error
+		Expected string
+	}{
+		{
+			Cs: ClusterSpec{
+				ApiProvider: xplane,
+			},
+			Desc:     "XplaneCspec",
+			Err:      nil,
+			Expected: "xplane-cluster-autoscaler",
+		},
+		{
+			Cs: ClusterSpec{
+				ApiProvider: capi,
+			},
+			Desc:     "CAPICspec",
+			Err:      nil,
+			Expected: "capi-cluster-autoscaler",
+		},
+		{
+			Cs: ClusterSpec{
+				ApiProvider: "unknown",
+			},
+			Desc:     "InvalidAPIProviderCspec",
+			Err:      ErrInvalidAPIProvider,
+			Expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			name, err := ClusterAutoscalerSubchartNameFromClusterSpec(&tc.Cs)
+			require.Equal(t, tc.Err, err)
+			require.Equal(t, tc.Expected, name)
+		})
+	}
+}

--- a/pkg/clusterspec/utils.go
+++ b/pkg/clusterspec/utils.go
@@ -3,18 +3,21 @@ package clusterspec
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"sort"
 )
 
 const (
-	aws   = "aws"
-	gcp   = "gcp"
-	azure = "azure"
+	aws    = "aws"
+	gcp    = "gcp"
+	azure  = "azure"
+	capi   = "capi"
+	xplane = "xplane"
 )
 
 var (
 	ValidApiProviders = map[string]bool{
-		"capi":   true,
-		"xplane": true,
+		capi:   true,
+		xplane: true,
 	}
 	ValidCloudProviders = map[string]bool{
 		aws:   true,
@@ -68,10 +71,22 @@ var (
 	}
 )
 
+var (
+	ErrInvalidAPIProvider = fmt.Errorf("invalid api provider, the valid values are: %s",
+		ValidValues(ValidApiProviders))
+	ErrInvalidCloudProvider = fmt.Errorf("invalid cloud provider, the valid values are: %s",
+		ValidValues(ValidCloudProviders))
+)
+
 func ValidValues(vals map[string]bool) string {
+	var allKeys []string
+	for key, _ := range vals {
+		allKeys = append(allKeys, key)
+	}
+	sort.Strings(allKeys)
 	var ret string
 	var i int
-	for val, _ := range vals {
+	for _, val := range allKeys {
 		var sep string
 		if i > 0 {
 			sep = "|"
@@ -84,16 +99,14 @@ func ValidValues(vals map[string]bool) string {
 
 func ValidApiProvider(apiProvider string) error {
 	if !ValidApiProviders[apiProvider] {
-		return fmt.Errorf("invalid api provider, the valid values are: %s",
-			ValidValues(ValidApiProviders))
+		return ErrInvalidAPIProvider
 	}
 	return nil
 }
 
 func ValidCloudProviderAndClusterType(cloudProvider string, clusterType string) error {
 	if !ValidCloudProviders[cloudProvider] {
-		return fmt.Errorf("invalid cloud provider, the valid values are: %s",
-			ValidValues(ValidCloudProviders))
+		return ErrInvalidCloudProvider
 	}
 	if !ValidClusterTypesByCloud[cloudProvider][clusterType] {
 		return fmt.Errorf("invalid cluster type, the valid values are: %s",


### PR DESCRIPTION
- ValidValues now sorts map keys to result in the same error, this was needed to check errors in the test cases needed to check errors in the test cases.
- Test cases for helper functions in `pkg/clusterspec` excluding those functions requiring a kubeclient.

Aha! Link: https://pf9.aha.io/features/ARLON-278