### PR TITLE
Add goreleaser github action

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - '!v0.3*'
 jobs:
   goreleaser:
     environment: arlon

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -38,7 +38,7 @@ jobs:
       -
         name: Run package tests
         run: |
-          go test -v ./pkg/...
+          make pkgtest
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,60 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  goreleaser:
+    environment: arlon
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      -
+        name: Cache go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      -
+        name: Test controllers
+        uses: phalanks/envtest-action@v1.0.0-rc
+        with:
+          version: '0.20.2'
+          args: './controllers/...'
+      -
+        name: Run package tests
+        run: |
+          go test -v ./pkg/...
+      -
+        name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
 
 archives:
   - id: 'cli'
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}_{{ .Version }}'
     replacements:
       darwin: 'Darwin'
       linux: 'Linux'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,52 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    - make fmt
+    - make vet
+builds:
+  - id: 'cli'
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      #      - windows # coming soon?
+      - darwin
+    goarch:
+      - 'amd64'
+      - '386'
+      - 'arm64'
+    ignore:
+      - goos: 'darwin'
+        goarch: '386'
+      - goos: 'linux'
+        goarch: 'arm'
+        goarm: '7'
+      - goarm: 'mips64'
+      - gomips: 'hardfloat'
+      - goamd64: 'v4'
+    skip: false
+    no_unique_dist_dir: true
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    binary: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}_v{{ .Version }}'
+
+archives:
+  - id: 'cli'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    replacements:
+      darwin: 'Darwin'
+      linux: 'Linux'
+      windows: 'Windows'
+      386: 'i386'
+      amd64: 'x86_64'
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - 'refactor'
+      - 'minor fix'
+      - 'cleanup'

--- a/Makefile
+++ b/Makefile
@@ -114,3 +114,6 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
+
+pkgtest:
+	go test -v ./pkg/...


### PR DESCRIPTION
This partly fixes [#60 Create Compiled Arlon CLI for Linux and the Build Infrastructure ](https://github.com/arlonproj/arlon/issues/60 )

goreleaser allows the Arlon team to publish releases on GitHub. The configuration is YAML based and feature rich. 