### PR TITLE
added cluster ngupdate command for next-gen clusters

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -20,5 +20,6 @@ func NewCommand() *cobra.Command {
 	command.AddCommand(createClusterCommand())
 	command.AddCommand(getClusterCommand())
 	command.AddCommand(deleteClusterCommand())
+	command.AddCommand(ngupdateClusterCommand())
 	return command
 }

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -94,7 +94,7 @@ func createClusterCommand() *cobra.Command {
 				profileApp, err = cluster.CreateProfileApp(profileAppName,
 					appIf, argocdNs, clusterName, prof, createInArgoCd)
 				if err != nil {
-					return fmt.Errorf("failed to profile app: %s", err)
+					return fmt.Errorf("failed to create profile app: %s", err)
 				}
 			}
 			if outputYaml {

--- a/cmd/cluster/ngupdate.go
+++ b/cmd/cluster/ngupdate.go
@@ -18,7 +18,7 @@ func ngupdateClusterCommand() *cobra.Command {
 	var argocdNs string
 	var arlonNs string
 	var profileName string
-	var deleteProfileName string
+	var deleteProfileName bool
 	command := &cobra.Command{
 		Use:   "ngupdate <clustername> [flags]",
 		Short: "update existing next-gen cluster",
@@ -40,7 +40,7 @@ func ngupdateClusterCommand() *cobra.Command {
 			if len(apps.Items) == 0 {
 				return fmt.Errorf("Failed to get the given cluster")
 			}
-			if deleteProfileName == "" {
+			if !deleteProfileName {
 				_, err = cluster.NgUpdate(appIf, config, argocdNs, arlonNs, name, profileName, true)
 				if err != nil {
 
@@ -59,6 +59,6 @@ func ngupdateClusterCommand() *cobra.Command {
 	command.Flags().StringVar(&argocdNs, "argocd-ns", "argocd", "the argocd namespace")
 	command.Flags().StringVar(&arlonNs, "arlon-ns", "arlon", "the arlon namespace")
 	command.Flags().StringVar(&profileName, "profile", "", "the configuration profile to use")
-	command.Flags().StringVar(&deleteProfileName, "delete-profile", "", "the configuration profile to be deleted")
+	command.Flags().BoolVar(&deleteProfileName, "delete-profile", false, "the configuration profile to be deleted")
 	return command
 }

--- a/cmd/cluster/ngupdate.go
+++ b/cmd/cluster/ngupdate.go
@@ -47,7 +47,7 @@ func ngupdateClusterCommand() *cobra.Command {
 					return fmt.Errorf("Error: %s", err)
 				}
 			} else {
-				err = cluster.DestructProfileApp(appIf, name)
+				err = cluster.DestroyProfileApps(appIf, name)
 				if err != nil {
 					return fmt.Errorf("Failed to delete the profile app")
 				}

--- a/cmd/cluster/ngupdate.go
+++ b/cmd/cluster/ngupdate.go
@@ -32,8 +32,9 @@ func ngupdateClusterCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get k8s client config: %s", err)
 			}
+			selector := "arlon-cluster=" + name + ",arlon-type=cluster-app"
 			apps, err := appIf.List(context.Background(),
-				&argoapp.ApplicationQuery{Selector: "arlon-cluster=" + name + ",arlon-type=cluster-app"})
+				&argoapp.ApplicationQuery{Selector: &selector})
 			if err != nil {
 				return fmt.Errorf("failed to list apps related to cluster: %s", err)
 			}

--- a/cmd/cluster/ngupdate.go
+++ b/cmd/cluster/ngupdate.go
@@ -1,0 +1,64 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/argoproj/argo-cd/v2/util/io"
+	"github.com/arlonproj/arlon/pkg/argocd"
+	"github.com/arlonproj/arlon/pkg/cluster"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func ngupdateClusterCommand() *cobra.Command {
+	var clientConfig clientcmd.ClientConfig
+	var argocdNs string
+	var arlonNs string
+	var profileName string
+	var deleteProfileName string
+	command := &cobra.Command{
+		Use:   "ngupdate <clustername> [flags]",
+		Short: "update existing next-gen cluster",
+		Long:  "update existing next-gen cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			name := args[0]
+			conn, appIf := argocd.NewArgocdClientOrDie("").NewApplicationClientOrDie()
+			defer io.Close(conn)
+			config, err := clientConfig.ClientConfig()
+			if err != nil {
+				return fmt.Errorf("failed to get k8s client config: %s", err)
+			}
+			apps, err := appIf.List(context.Background(),
+				&argoapp.ApplicationQuery{Selector: "arlon-cluster=" + name + ",arlon-type=cluster-app"})
+			if err != nil {
+				return fmt.Errorf("failed to list apps related to cluster: %s", err)
+			}
+			if len(apps.Items) == 0 {
+				return fmt.Errorf("Failed to get the given cluster")
+			}
+			if deleteProfileName == "" {
+				_, err = cluster.NgUpdate(appIf, config, argocdNs, arlonNs, name, profileName, true)
+				if err != nil {
+
+					return fmt.Errorf("Error: %s", err)
+				}
+			} else {
+				err = cluster.DestructProfileApp(appIf, name)
+				if err != nil {
+					return fmt.Errorf("Failed to delete the profile app")
+				}
+			}
+			return nil
+		},
+	}
+	clientConfig = cli.AddKubectlFlagsToCmd(command)
+	command.Flags().StringVar(&argocdNs, "argocd-ns", "argocd", "the argocd namespace")
+	command.Flags().StringVar(&arlonNs, "arlon-ns", "arlon", "the arlon namespace")
+	command.Flags().StringVar(&profileName, "profile", "", "the configuration profile to use")
+	command.Flags().StringVar(&deleteProfileName, "delete-profile", "", "the configuration profile to be deleted")
+	return command
+}

--- a/cmd/cluster/ngupdate.go
+++ b/cmd/cluster/ngupdate.go
@@ -60,6 +60,6 @@ func ngupdateClusterCommand() *cobra.Command {
 	command.Flags().StringVar(&argocdNs, "argocd-ns", "argocd", "the argocd namespace")
 	command.Flags().StringVar(&arlonNs, "arlon-ns", "arlon", "the arlon namespace")
 	command.Flags().StringVar(&profileName, "profile", "", "the configuration profile to use")
-	command.Flags().BoolVar(&deleteProfileName, "delete-profile", false, "the configuration profile to be deleted")
+	command.Flags().BoolVar(&deleteProfileName, "delete-profile", false, "delete the existing profile app from the cluster")
 	return command
 }

--- a/pkg/cluster/ngupdate.go
+++ b/pkg/cluster/ngupdate.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/arlonproj/arlon/pkg/profile"
+	restclient "k8s.io/client-go/rest"
+)
+
+func NgUpdate(
+	appIf argoapp.ApplicationServiceClient,
+	config *restclient.Config,
+	argocdNs,
+	arlonNs,
+	clusterName,
+	profileName string,
+	updateInArgoCd bool,
+) (*argoappv1.Application, error) {
+
+	prof, err := profile.Get(config, profileName, arlonNs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get profile: %s", err)
+	}
+	apps, err := appIf.List(context.Background(),
+		&argoapp.ApplicationQuery{Selector: "arlon-cluster=" + clusterName + ",arlon-type=profile-app"})
+	if len(apps.Items) != 0 {
+		DestructProfileApp(appIf, clusterName)
+	}
+	profileAppName := fmt.Sprintf("%s-profile-%s", clusterName, prof.Name)
+	profileApp, err := CreateProfileApp(profileAppName,
+		appIf, argocdNs, clusterName, prof, updateInArgoCd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create profile app: %s", err)
+	}
+	return profileApp, nil
+}

--- a/pkg/cluster/ngupdate.go
+++ b/pkg/cluster/ngupdate.go
@@ -24,6 +24,9 @@ func NgUpdate(
 		return nil, fmt.Errorf("failed to get profile: %s", err)
 	}
 	DestroyProfileApps(appIf, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to delete profile app: %s", err)
+	}
 	profileAppName := fmt.Sprintf("%s-profile-%s", clusterName, prof.Name)
 	profileApp, err := CreateProfileApp(profileAppName,
 		appIf, argocdNs, clusterName, prof, updateInArgoCd)

--- a/pkg/cluster/ngupdate.go
+++ b/pkg/cluster/ngupdate.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"context"
 	"fmt"
 
 	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
@@ -24,8 +23,6 @@ func NgUpdate(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get profile: %s", err)
 	}
-	_, err = appIf.List(context.Background(),
-		&argoapp.ApplicationQuery{Selector: "arlon-cluster=" + clusterName + ",arlon-type=profile-app"})
 	DestroyProfileApps(appIf, clusterName)
 	profileAppName := fmt.Sprintf("%s-profile-%s", clusterName, prof.Name)
 	profileApp, err := CreateProfileApp(profileAppName,

--- a/pkg/cluster/ngupdate.go
+++ b/pkg/cluster/ngupdate.go
@@ -23,7 +23,7 @@ func NgUpdate(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get profile: %s", err)
 	}
-	DestroyProfileApps(appIf, clusterName)
+	err = DestroyProfileApps(appIf, clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to delete profile app: %s", err)
 	}

--- a/pkg/cluster/ngupdate.go
+++ b/pkg/cluster/ngupdate.go
@@ -24,11 +24,9 @@ func NgUpdate(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get profile: %s", err)
 	}
-	apps, err := appIf.List(context.Background(),
+	_, err = appIf.List(context.Background(),
 		&argoapp.ApplicationQuery{Selector: "arlon-cluster=" + clusterName + ",arlon-type=profile-app"})
-	if len(apps.Items) != 0 {
-		DestructProfileApp(appIf, clusterName)
-	}
+	DestroyProfileApps(appIf, clusterName)
 	profileAppName := fmt.Sprintf("%s-profile-%s", clusterName, prof.Name)
 	profileApp, err := CreateProfileApp(profileAppName,
 		appIf, argocdNs, clusterName, prof, updateInArgoCd)

--- a/pkg/cluster/profile_app.go
+++ b/pkg/cluster/profile_app.go
@@ -37,8 +37,9 @@ func DestroyProfileApps(
 	clusterName string,
 ) error {
 	var err error
+	selector := "arlon-cluster=" + clusterName + ",arlon-type=profile-app"
 	apps, err := appIf.List(context.Background(),
-		&argoapp.ApplicationQuery{Selector: "arlon-cluster=" + clusterName + ",arlon-type=profile-app"})
+		&argoapp.ApplicationQuery{Selector: &selector})
 	for _, app := range apps.Items {
 		cascade := true
 		_, err = appIf.Delete(

--- a/pkg/cluster/profile_app.go
+++ b/pkg/cluster/profile_app.go
@@ -30,3 +30,26 @@ func CreateProfileApp(
 	}
 	return app, nil
 }
+func DestructProfileApp(
+	appIf argoapp.ApplicationServiceClient,
+	clusterName string,
+) error {
+	var err error
+	apps, err := appIf.List(context.Background(),
+		&argoapp.ApplicationQuery{Selector: "arlon-cluster=" + clusterName + ",arlon-type=profile-app"})
+	for _, app := range apps.Items {
+		cascade := true
+		_, err = appIf.Delete(
+			context.Background(),
+			&argoapp.ApplicationDeleteRequest{
+				Name:    &app.Name,
+				Cascade: &cascade,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to delete related profile app %s: %s",
+				app.Name, err)
+		}
+		fmt.Println("deleted related app:", app.Name)
+	}
+	return err
+}

--- a/pkg/cluster/profile_app.go
+++ b/pkg/cluster/profile_app.go
@@ -30,7 +30,9 @@ func CreateProfileApp(
 	}
 	return app, nil
 }
-func DestructProfileApp(
+
+// DestroyProfileApp destroys a profile-app that accompanies an arlon-app for gen2 clusters
+func DestroyProfileApps(
 	appIf argoapp.ApplicationServiceClient,
 	clusterName string,
 ) error {
@@ -49,7 +51,6 @@ func DestructProfileApp(
 			return fmt.Errorf("failed to delete related profile app %s: %s",
 				app.Name, err)
 		}
-		fmt.Println("deleted related app:", app.Name)
 	}
 	return err
 }

--- a/pkg/gitrepo/gitrepo.go
+++ b/pkg/gitrepo/gitrepo.go
@@ -3,12 +3,13 @@ package gitrepo
 import (
 	"errors"
 	"fmt"
-	argocdio "github.com/argoproj/argo-cd/v2/util/io"
-	"github.com/argoproj/argo-cd/v2/util/localconfig"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"os"
 	"path/filepath"
+
+	argocdio "github.com/argoproj/argo-cd/v2/util/io"
+	"github.com/argoproj/argo-cd/v2/util/localconfig"
+	"k8s.io/apimachinery/pkg/util/json"
 )
 
 type RepoCtx struct {
@@ -104,7 +105,7 @@ func GetRepoUrl(repoAlias string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	argocdio.Close(cfgFile)
+	defer argocdio.Close(cfgFile)
 	repoCtx, err := getAlias(repoAlias, cfgFile)
 	if err != nil {
 		if !errors.Is(err, ErrNotFound) {


### PR DESCRIPTION
This fixes https://github.com/arlonproj/arlon/issues/109 . Added a command "arlon cluster ngupdate" which is the cluster update version for next-gen clusters. This code change has been tested and is working successfuly.

Aha! Link: https://pf9.aha.io/features/ARLON-109