### PR TITLE
Update main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,9 +326,11 @@ and it is registered as a git repo in ArgoCD. The tutorial will assume
 the existence of these environment variables:
 - `${ARLON_REPO}`: where the arlon repo is locally checked out
 - `${WORKSPACE_REPO}`: where the workspace repo is locally checked out
-- `${WORKSPACE_REPO_URL}`: the workspace repo's git URL. It typically looks 
-like `https://github.com/${username}/${reponame}.git`
-- Additionally, examples assuming `arlon git register` has been used to register "default" and a "prod" aliases will also be given.
+- `${WORKSPACE_REPO_URL}`: the workspace repo's git URL. It typically looks like `https://github.com/${username}/${reponame}.git`
+- `${CLOUD_REGION}`: the region where you want to deploy example clusters and workloads (e.g. us-west-2)
+- `${SSH_KEY_NAME}`: the name of a public ssh key name registered in your cloud account, to enable ssh to your cluster nodes
+
+Additionally, for examples assuming `arlon git register`, "default" and a "prod" git repo aliases will also be given.
 
 _Note: for the best experience, make sure your workspace repo is configured
 to send change notifications to ArgoCD via a webhook. See the Installation section for details._
@@ -340,18 +342,18 @@ One of the cluster specs is for an unconfigured API provider (Crossplane);
 this is for illustrative purposes, since we will not use it in this tutorial.
 
 ```
-arlon clusterspec create capi-kubeadm-3node --api capi --cloud aws --type kubeadm --kubeversion v1.18.16 --nodecount 3 --nodetype t2.medium --tags devel,test --desc "3 node kubeadm for dev/test"
-arlon clusterspec create capi-eks --api capi --cloud aws --type eks --kubeversion v1.18.16 --nodecount 2 --nodetype t2.large --tags staging --desc "2 node eks for general purpose"
-arlon clusterspec create xplane-eks-3node --api xplane --cloud aws --type eks --kubeversion v1.18.16 --nodecount 4 --nodetype t2.small --tags experimental --desc "4 node eks managed by crossplane"
+arlon clusterspec create capi-kubeadm-3node --api capi --cloud aws --type kubeadm --kubeversion v1.18.16 --nodecount 3 --nodetype t2.medium --tags devel,test --desc "3 node kubeadm for dev/test" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
+arlon clusterspec create capi-eks --api capi --cloud aws --type eks --kubeversion v1.18.16 --nodecount 2 --nodetype t2.large --tags staging --desc "2 node eks for general purpose" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
+arlon clusterspec create xplane-eks-3node --api xplane --cloud aws --type eks --kubeversion v1.18.16 --nodecount 4 --nodetype t2.small --tags experimental --desc "4 node eks managed by crossplane" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
 ```
 
 Ensure you can now list the cluster specs:
 ```
 $ arlon clusterspec list
-NAME                APIPROV  CLOUDPROV  TYPE     KUBEVERSION  NODETYPE   NODECOUNT  TAGS          DESCRIPTION
-capi-eks            capi     aws        eks      v1.18.16     t2.large   2          staging       2 node eks for general purpose
-capi-kubeadm-3node  capi     aws        kubeadm  v1.18.16     t2.medium  3          devel,test    3 node kubeadm for dev/test
-xplane-eks-3node    xplane   aws        eks      v1.18.16     t2.small   4          experimental  4 node eks managed by crossplane
+NAME                APIPROV  CLOUDPROV  TYPE     KUBEVERSION  NODETYPE   NODECNT  MSTNODECNT  SSHKEY  CAS    CASMIN  CASMAX  TAGS          DESCRIPTION
+capi-eks            capi     aws        eks      v1.18.16     t2.large   2        3           leb     false  1       9       staging       2 node eks for general purpose
+capi-kubeadm-3node  capi     aws        kubeadm  v1.18.16     t2.medium  3        3           leb     false  1       9       devel,test    3 node kubeadm for dev/test
+xplane-eks-3node    xplane   aws        eks      v1.18.16     t2.small   4        3           leb     false  1       9       experimental  4 node eks managed by crossplane
 ```
 
 ## Bundles

--- a/README.md
+++ b/README.md
@@ -342,18 +342,18 @@ One of the cluster specs is for an unconfigured API provider (Crossplane);
 this is for illustrative purposes, since we will not use it in this tutorial.
 
 ```
-arlon clusterspec create capi-kubeadm-3node --api capi --cloud aws --type kubeadm --kubeversion v1.18.16 --nodecount 3 --nodetype t2.medium --tags devel,test --desc "3 node kubeadm for dev/test" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
-arlon clusterspec create capi-eks --api capi --cloud aws --type eks --kubeversion v1.18.16 --nodecount 2 --nodetype t2.large --tags staging --desc "2 node eks for general purpose" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
-arlon clusterspec create xplane-eks-3node --api xplane --cloud aws --type eks --kubeversion v1.18.16 --nodecount 4 --nodetype t2.small --tags experimental --desc "4 node eks managed by crossplane" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
+arlon clusterspec create capi-kubeadm-3node --api capi --cloud aws --type kubeadm --kubeversion v1.21.10 --nodecount 3 --nodetype t2.medium --tags devel,test --desc "3 node kubeadm for dev/test" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
+arlon clusterspec create capi-eks --api capi --cloud aws --type eks --kubeversion v1.21.10 --nodecount 2 --nodetype t2.large --tags staging --desc "2 node eks for general purpose" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
+arlon clusterspec create xplane-eks-3node --api xplane --cloud aws --type eks --kubeversion v1.21.10 --nodecount 4 --nodetype t2.small --tags experimental --desc "4 node eks managed by crossplane" --region ${CLOUD_REGION} --sshkey ${SSH_KEY_NAME}
 ```
 
 Ensure you can now list the cluster specs:
 ```
 $ arlon clusterspec list
 NAME                APIPROV  CLOUDPROV  TYPE     KUBEVERSION  NODETYPE   NODECNT  MSTNODECNT  SSHKEY  CAS    CASMIN  CASMAX  TAGS          DESCRIPTION
-capi-eks            capi     aws        eks      v1.18.16     t2.large   2        3           leb     false  1       9       staging       2 node eks for general purpose
-capi-kubeadm-3node  capi     aws        kubeadm  v1.18.16     t2.medium  3        3           leb     false  1       9       devel,test    3 node kubeadm for dev/test
-xplane-eks-3node    xplane   aws        eks      v1.18.16     t2.small   4        3           leb     false  1       9       experimental  4 node eks managed by crossplane
+capi-eks            capi     aws        eks      v1.21.10     t2.large   2        3           leb     false  1       9       staging       2 node eks for general purpose
+capi-kubeadm-3node  capi     aws        kubeadm  v1.21.10     t2.medium  3        3           leb     false  1       9       devel,test    3 node kubeadm for dev/test
+xplane-eks-3node    xplane   aws        eks      v1.21.10     t2.small   4        3           leb     false  1       9       experimental  4 node eks managed by crossplane
 ```
 
 ## Bundles

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ We can now create profiles to group bundles into useful, deployable sets.
 First, create a static profile containing bundles xenial-static and guestbook-static:
 
 ```
-arlon profile create static-1 --static --bundles guestbook-static,xenial --desc "static profile 1" --tags examples
+arlon profile create static-1 --static --bundles guestbook-static,xenial-static --desc "static profile 1" --tags examples
 ```
 
 Secondly, create a dynamic version of the same profile. We'll store the compiled
@@ -446,13 +446,13 @@ form of the profile in the `profiles/dynamic-1` directory of the workspace repo.
 it manually; instead, the arlon CLI will create it for us, and it will push
 the change to git:
 ```
-arlon profile create dynamic-1 --repo-url ${WORKSPACE_REPO_URL} --repo-base-path profiles --bundles guestbook-static,xenial --desc "dynamic test 1" --tags examples
+arlon profile create dynamic-1 --repo-url ${WORKSPACE_REPO_URL} --repo-base-path profiles --bundles guestbook-static,xenial-static --desc "dynamic test 1" --tags examples
             # OR
 # using repository aliases
   # using the default alias
-arlon profile create dynamic-1 --repo-base-path profiles --bundles guestbook-static,xenial --desc "dynamic test 1" --tags examples
+arlon profile create dynamic-1 --repo-base-path profiles --bundles guestbook-static,xenial-static --desc "dynamic test 1" --tags examples
   # using the prod alias
-arlon profile create dynamic-1 --repo-alias prod --repo-base-path profiles --bundles guestbook-static,xenial --desc "dynamic test 1" --tags examples
+arlon profile create dynamic-1 --repo-alias prod --repo-base-path profiles --bundles guestbook-static,xenial-static --desc "dynamic test 1" --tags examples
 ```
 _Note: the `--repo-base-path profiles` option tells `arlon` to create the profile
 under a base directory `profiles/` (to be created if it doesn't exist). That
@@ -483,21 +483,21 @@ This is not done for `guestbook-dynamic` because it is dynamic.
 Finally, we create another variant of the same profile, with the only difference
 being the addition of Calico bundle. It'll be used on clusters that need a CNI provider:
 ```
-arlon profile create dynamic-2-calico --repo-url ${WORKSPACE_REPO_URL} --repo-base-path profiles --bundles calico,guestbook-dynamic,xenial --desc "dynamic test 1" --tags examples
+arlon profile create dynamic-2-calico --repo-url ${WORKSPACE_REPO_URL} --repo-base-path profiles --bundles calico,guestbook-dynamic,xenial-static --desc "dynamic test 1" --tags examples
             # OR
 # using repository aliases
   # using the default alias
-arlon profile create dynamic-2-calico --repo-base-path profiles --bundles calico,guestbook-dynamic,xenial --desc "dynamic test 1" --tags examples
+arlon profile create dynamic-2-calico --repo-base-path profiles --bundles calico,guestbook-dynamic,xenial-static --desc "dynamic test 1" --tags examples
   # using the prod alias
-arlon profile create dynamic-2-calico --repo-alias prod --repo-base-path profiles --bundles calico,guestbook-dynamic,xenial --desc "dynamic test 1" --tags examples
+arlon profile create dynamic-2-calico --repo-alias prod --repo-base-path profiles --bundles calico,guestbook-dynamic,xenial-static --desc "dynamic test 1" --tags examples
 ```
 Listing the profiles should show:
 ```
 $ arlon profile list
-NAME              TYPE     BUNDLES                          REPO-URL               REPO-PATH                  TAGS         DESCRIPTION
-dynamic-1         dynamic  guestbook-static,xenial          ${WORKSPACE_REPO_URL}  profiles/dynamic-1         examples     dynamic test 1
-dynamic-2-calico  dynamic  calico,guestbook-static,xenial   ${WORKSPACE_REPO_URL}  profiles/dynamic-2-calico  examples     dynamic test 1
-static-1          static   guestbook-dynamic,xenial         (N/A)                  (N/A)                      examples     static profile 1
+NAME              TYPE     BUNDLES                                 REPO-URL               REPO-PATH                  TAGS         DESCRIPTION
+dynamic-1         dynamic  guestbook-static,xenial-static          ${WORKSPACE_REPO_URL}  profiles/dynamic-1         examples     dynamic test 1
+dynamic-2-calico  dynamic  calico,guestbook-static,xenial-static   ${WORKSPACE_REPO_URL}  profiles/dynamic-2-calico  examples     dynamic test 1
+static-1          static   guestbook-dynamic,xenial-static         (N/A)                  (N/A)                      examples     static profile 1
 ```
 
 ## Clusters (gen1)
@@ -630,7 +630,7 @@ from `dynamic-1` by specifying a new bundle set:
 ```
 arlon profile update dynamic-1 --bundles xenial
 ```
-Since the old bundle set was `guestbook-static,xenial`, that command resulted
+Since the old bundle set was `guestbook-static,xenial-static`, that command resulted
 in the removal of `guestbook-static` from the profile.
 In the UI, observe the `eks-1-profile-dynamic-1` app going through Sync
 and Progressing phases, eventually reaching the healthy (green) state.


### PR DESCRIPTION
- Clusterspec creation now requires 2 additional arguments
- Some uses of "xenial" bundle should be named "xenial-static"
- Kubernetes v1.18.16 no longer available with CAPA, update to v1.21.1
- Other misc changes found during testing