### PR TITLE
Update ci.yml to use go v1.19 and listed improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
           cache: 'pip' # caching pip dependencies
       - run: pip install -r docs/requirements.txt
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.19
+        check-latest: true
+        cache: true
     - name: Build
       run: go build -v ./...
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
-      - run: pip install mkdocs-material 
+          python-version: 3.10
+          cache: 'pip' # caching pip dependencies
+      - run: pip install -r docs/requirements.txt
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
* Update actions checkout and setup-go to latest version
* Use go 1.19 to build 
* Add caching for go and python 
* Install python dependencies from docs/requirements.txt