### PR TITLE
Update Makefile to fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,13 @@ build-cli: fmt vet ## Build CLI binary (with the current OS and CPU architecture
 build-cli-linux: fmt vet ## Build CLI binary for Linux
 	GOOS=linux GOARCH=amd64 go build -o bin/arlon main.go
 
-build-cli-mac: fmt vet ## Build CLI binary for Mac (AMD/ Intel CPU)
+build-cli-mac-amd64: fmt vet ## Build CLI binary for Mac (AMD/ Intel CPU)
 	GOOS=darwin GOARCH=amd64 go build -o bin/arlon main.go
 
-build-cli-mac: fmt vet ## Build CLI binary for Mac (Apple Silicon)
+build-cli-mac-arm64: fmt vet ## Build CLI binary for Mac (Apple Silicon)
 	GOOS=darwin GOARCH=arm64 go build -o bin/arlon main.go
+	
+build-cli-mac: build-cli-mac-arm64
 
 # Arlon has not been tested on Windows yet.
 build-cli-win: fmt vet ## Build CLI binary for Windows.


### PR DESCRIPTION
Minor bugfix in Makefile to eliminate warnings since the build-cli-mac target was earlier repeated (for two different CPU architectures)