### PR TITLE
change trigger for goreleaser ci

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       -
         name: Cache go modules
         uses: actions/cache@v3

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -3,6 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
+      - '*'
       - '!v0.3*'
 jobs:
   goreleaser:

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Cache go modules
         uses: actions/cache@v3


### PR DESCRIPTION
The trigger
`- '!v0.3*' `
excludes v0.3.x releases, but doesn't include other releases

The proper trigger for this condition is 
```yaml
- '*'    # include all tags
- '!v0.3*'    # exclude v0.3x tags
```

Aha! Link: https://pf9.aha.io/features/ARLON-287