### PR TITLE
Fix profile delete bug.

### DIFF
--- a/cmd/profile/delete.go
+++ b/cmd/profile/delete.go
@@ -1,10 +1,13 @@
 package profile
 
 import (
+	"context"
 	"fmt"
-	"github.com/arlonproj/arlon/pkg/profile"
+	"github.com/argoproj/argo-cd/v2/util/errors"
+	v1 "github.com/arlonproj/arlon/api/v1"
+	"github.com/arlonproj/arlon/pkg/controller"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -33,6 +36,16 @@ func deleteProfileCommand() *cobra.Command {
 }
 
 func deleteProfile(config *restclient.Config, ns string, profileName string) error {
-	kubeClient := kubernetes.NewForConfigOrDie(config)
-	return profile.Delete(kubeClient, ns, profileName)
+	ctrl, err := controller.NewClient(config)
+	errors.CheckError(err)
+	ctx := context.Background()
+	var prof v1.Profile
+	err = ctrl.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      profileName,
+	}, &prof)
+	errors.CheckError(err)
+	return ctrl. /*ALT*/ Delete(ctx, &prof, nil)
+	//kubeClient := kubernetes.NewForConfigOrDie(config)
+	//return profile.Delete(kubeClient, ns, profileName)
 }

--- a/cmd/profile/delete.go
+++ b/cmd/profile/delete.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 import "github.com/argoproj/argo-cd/v2/util/cli"
@@ -45,7 +46,7 @@ func deleteProfile(config *restclient.Config, ns string, profileName string) err
 		Name:      profileName,
 	}, &prof)
 	errors.CheckError(err)
-	return ctrl. /*ALT*/ Delete(ctx, &prof, nil)
+	return ctrl. /*ALT*/ Delete(ctx, &prof, &client.DeleteOptions{})
 	//kubeClient := kubernetes.NewForConfigOrDie(config)
 	//return profile.Delete(kubeClient, ns, profileName)
 }

--- a/cmd/profile/delete.go
+++ b/cmd/profile/delete.go
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/arlonproj/arlon/api/v1"
 	"github.com/arlonproj/arlon/pkg/controller"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,11 +40,12 @@ func deleteProfile(config *restclient.Config, ns string, profileName string) err
 	ctrl, err := controller.NewClient(config)
 	errors.CheckError(err)
 	ctx := context.Background()
-	var prof v1.Profile
-	err = ctrl.Get(ctx, types.NamespacedName{
-		Namespace: ns,
-		Name:      profileName,
-	}, &prof)
-	errors.CheckError(err)
+	prof := v1.Profile{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      profileName,
+			Namespace: ns,
+		},
+	}
 	return ctrl.Delete(ctx, &prof, &client.DeleteOptions{})
 }

--- a/cmd/profile/delete.go
+++ b/cmd/profile/delete.go
@@ -46,7 +46,5 @@ func deleteProfile(config *restclient.Config, ns string, profileName string) err
 		Name:      profileName,
 	}, &prof)
 	errors.CheckError(err)
-	return ctrl. /*ALT*/ Delete(ctx, &prof, &client.DeleteOptions{})
-	//kubeClient := kubernetes.NewForConfigOrDie(config)
-	//return profile.Delete(kubeClient, ns, profileName)
+	return ctrl.Delete(ctx, &prof, &client.DeleteOptions{})
 }

--- a/pkg/profile/delete.go
+++ b/pkg/profile/delete.go
@@ -3,11 +3,13 @@ package profile
 import (
 	"context"
 	"fmt"
+	v1 "github.com/arlonproj/arlon/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Delete(
+func DeleteLegacy(
 	kubeClient *kubernetes.Clientset,
 	ns string,
 	profileName string,
@@ -19,4 +21,16 @@ func Delete(
 		return fmt.Errorf("failed to delete profile: %s", err)
 	}
 	return nil
+}
+
+func Delete(cli client.Client, ns, profileName string) error {
+	ctx := context.Background()
+	prof := v1.Profile{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      profileName,
+			Namespace: ns,
+		},
+	}
+	return cli.Delete(ctx, &prof, &client.DeleteOptions{})
 }


### PR DESCRIPTION
After changing profiles from config maps to CRs, the delete logic was still searching for config maps, this PR fixes that bug.
Testing output(testbed was generated using the `testing/ensure_testbed.sh` script):
```shell
ubuntu@ip-172-31-28-20:~/arlon$ arlon profile list
NAME              GEN  TYPE     BUNDLES                                   REPO-URL                           REPO-PATH                  OVRDS  TAGS        DESCRIPTION
dynamic-1         2    dynamic  [guestbook-static xenial-static]          http://172.17.0.1:8188/myrepo.git  profiles/dynamic-1         0      [examples]  dynamic test 1
dynamic-2-calico  2    dynamic  [calico guestbook-dynamic xenial-static]  http://172.17.0.1:8188/myrepo.git  profiles/dynamic-2-calico  0      [examples]  dynamic test 2
static-1          2    static   [guestbook-static xenial-static]          (N/A)                              (N/A)                      0      [examples]  static profile 1
ubuntu@ip-172-31-28-20:~/arlon$ arlon profile delete dynamic-1
ubuntu@ip-172-31-28-20:~/arlon$ arlon profile list
NAME              GEN  TYPE     BUNDLES                                   REPO-URL                           REPO-PATH                  OVRDS  TAGS        DESCRIPTION
dynamic-2-calico  2    dynamic  [calico guestbook-dynamic xenial-static]  http://172.17.0.1:8188/myrepo.git  profiles/dynamic-2-calico  0      [examples]  dynamic test 2
static-1          2    static   [guestbook-static xenial-static]          (N/A)                              (N/A)                      0      [examples]  static profile 1
ubuntu@ip-172-31-28-20:~/arlon$ static-1
static-1: command not found
ubuntu@ip-172-31-28-20:~/arlon$ arlon profile delete static-1
ubuntu@ip-172-31-28-20:~/arlon$ arlon profile list
NAME              GEN  TYPE     BUNDLES                                   REPO-URL                           REPO-PATH                  OVRDS  TAGS        DESCRIPTION
dynamic-2-calico  2    dynamic  [calico guestbook-dynamic xenial-static]  http://172.17.0.1:8188/myrepo.git  profiles/dynamic-2-calico  0      [examples]  dynamic test 2
```
The controller uses the image built from this branch:
```yaml
    spec:
      containers:
      - command:
        - /arlon
        - controller
        - --argocd-config-path
        - /.argocd/config
        image: ghcr.io/arlonproj/arlon/controller:0.9.7-debug-devel-patch1
```

Aha! Link: https://pf9.aha.io/features/ARLON-291