### PR TITLE
Fix `make test` for v0.3 branch by updating controller-gen to v0.9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,22 @@ test: manifests generate fmt vet ## Run tests.
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/arlon main.go
 
+# goreleaser can invoke this target to produce binaries for different OS and CPU arch combinations
+build-cli: fmt vet ## Build CLI binary (with the current OS and CPU architecture) from the go env.
+	go build -o bin/arlon main.go
+
+build-cli-linux: fmt vet ## Build CLI binary for Linux
+	GOOS=linux GOARCH=amd64 go build -o bin/arlon main.go
+
+build-cli-mac-amd64: fmt vet ## Build CLI binary for Mac (AMD/ Intel CPU)
+	GOOS=darwin GOARCH=amd64 go build -o bin/arlon main.go
+
+build-cli-mac-arm64: fmt vet ## Build CLI binary for Mac (Apple Silicon)
+	GOOS=darwin GOARCH=arm64 go build -o bin/arlon main.go
+
+build-cli-mac: fmt vet
+	GOOS=darwin go build -o bin/arlon main.go
+
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
@@ -95,7 +111,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REPO_NAME ?= arlon
 # Image URL to use all building/pushing image targets
 IMG ?= $(REPO_SERVER)/$(REPO_ORG)/$(REPO_NAME)/controller:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -95,7 +95,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ test: manifests generate fmt vet ## Run tests.
 
 ##@ Build
 
+clean:
+	rm -rf ./testbin; rm -rf ./bin
+
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/arlon main.go
 

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the arlo v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=core.arlon.io
+// +kubebuilder:object:generate=true
+// +groupName=core.arlon.io
 package v1
 
 import (

--- a/config/crd/bases/core.arlon.io_callhomeconfigs.yaml
+++ b/config/crd/bases/core.arlon.io_callhomeconfigs.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: callhomeconfigs.core.arlon.io
 spec:
@@ -92,9 +91,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/core.arlon.io_callhomeconfigs.yaml
+++ b/config/crd/bases/core.arlon.io_callhomeconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: callhomeconfigs.core.arlon.io
 spec:

--- a/config/crd/bases/core.arlon.io_clusterregistrations.yaml
+++ b/config/crd/bases/core.arlon.io_clusterregistrations.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: clusterregistrations.core.arlon.io
 spec:
@@ -66,9 +65,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/core.arlon.io_clusterregistrations.yaml
+++ b/config/crd/bases/core.arlon.io_clusterregistrations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: clusterregistrations.core.arlon.io
 spec:

--- a/config/crd/bases/core.arlon.io_profiles.yaml
+++ b/config/crd/bases/core.arlon.io_profiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: profiles.core.arlon.io
 spec:

--- a/config/crd/bases/core.arlon.io_profiles.yaml
+++ b/config/crd/bases/core.arlon.io_profiles.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: profiles.core.arlon.io
 spec:
@@ -90,9 +89,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Fixes #197 [Some build actions like `make docker-build` fail since `make test` fails]
Also add the build-cli targets in Makefile 