### PR TITLE
fix #201: allow callhomeconfig controller to read svc account in cluster namespace

### DIFF
--- a/pkg/cluster/manifests/charts/capi-cluster-autoscaler/templates/rbac.yaml
+++ b/pkg/cluster/manifests/charts/capi-cluster-autoscaler/templates/rbac.yaml
@@ -37,3 +37,30 @@ rules:
       - list
       - update
       - watch
+---
+# The following allows arlon callhomeconfig controller to read the
+# cluster-autoscaler service account in the cluster namespace
+# in order to extract its token.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: serviceaccounts-reader
+  namespace: {{ .Values.global.clusterName }}
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: arlon-serviceaccounts-reader
+  namespace: {{ .Values.global.clusterName }}
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: arlon
+roleRef:
+  kind: Role
+  name: serviceaccounts-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes #201 
Arlon controller was missing RBAC permissions to read the `cluster-autoscaler` service account in the cluster namespace. I don't know why this wasn't a problem before during prior testing.

Testing: created new eks cluster with CAS enabled, and with a profile containing the CAS bundle. Verified that the autoscaler pod is running and healthy in the workload cluster.
