### PR TITLE
fix #234 - add renaming config for EKSConfigTemplate

### DIFF
--- a/pkg/basecluster/data.go
+++ b/pkg/basecluster/data.go
@@ -57,6 +57,12 @@ nameReference:
   fieldSpecs:
   - path: spec/template/spec/bootstrap/configRef/name
     kind: MachineDeployment
+- kind: EKSConfigTemplate
+  group: bootstrap.cluster.x-k8s.io
+  version: v1beta1
+  fieldSpecs:
+  - path: spec/template/spec/bootstrap/configRef/name
+    kind: MachineDeployment
 - kind: DockerCluster
   group: infrastructure.cluster.x-k8s.io
   version: v1beta1

--- a/pkg/basecluster/data.go
+++ b/pkg/basecluster/data.go
@@ -31,6 +31,14 @@ nameReference:
   fieldSpecs:
   - path: spec/controlPlaneRef/name
     kind: Cluster
+- kind: AWSManagedControlPlane
+  group: controlplane.cluster.x-k8s.io
+  version: v1beta1
+  fieldSpecs:
+  - path: spec/controlPlaneRef/name
+    kind: Cluster
+  - path: spec/infrastructureRef/name
+    kind: Cluster
 - kind: AWSMachine
   group: infrastructure.cluster.x-k8s.io
   version: v1beta1


### PR DESCRIPTION
When using an EKS manifest as base cluster
- The MachineDeployment resource references an EKSConfigTemplate resource, for which we were missing a renaming config in the `configurations.yaml` used by Kustomize.
- Similarly, Cluster has two references to AWSManagedControlPlane
