### PR TITLE
Fix #238: Set RootFS ReadOnly False

### DIFF
--- a/deploy/manifests/deploy.yaml
+++ b/deploy/manifests/deploy.yaml
@@ -55,7 +55,7 @@ spec:
           capabilities:
             drop:
             - all
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
The gRPC proxy socket created by the ArgoCD API client will fail to be created if the root FS is set to read only. Update the `securityContext` to set read only to `false`.

Aha! Link: https://pf9.aha.io/features/ARLON-318