### PR TITLE
Update golang from version 1.19 to 1.19.1 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - v0.3
+      - v0.9
   pull_request:
     branches:
       - main
       - v0.3
+      - v0.9
 
 jobs:
   build:
@@ -18,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.19.1
         check-latest: true
         cache: true
     - name: Build

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -5,6 +5,7 @@ on:
     tags:
       - '*'
       - '!v0.3*'
+      - '!v0.9*'
 jobs:
   goreleaser:
     environment: arlon
@@ -19,7 +20,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.19.1
       -
         name: Cache go modules
         uses: actions/cache@v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,11 +10,13 @@ on:
     branches:
       - main
       - v0.3
+      - v0.9
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
       - main
       - v0.3
+      - v0.9
   schedule:
     - cron: '28 1 * * 0'
 


### PR DESCRIPTION
* Update goreleaser action in v0.9 branch to use golang 1.19.1
* CI using golang 1.19.1