### PR TITLE
Reduce arlon binary size( #233) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clean:
 	rm -rf ./testbin; rm -rf ./bin
 
 build: generate fmt vet cluster-config ## Build manager binary.
-	go build --ldflags="-s -w" -o bin/arlon main.go
+	go build -ldflags '$(LD_FLAGS)' -o bin/arlon main.go
 
 cluster-config:
 	mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clean:
 	rm -rf ./testbin; rm -rf ./bin
 
 build: generate fmt vet cluster-config ## Build manager binary.
-	go build -o bin/arlon main.go
+	go build --ldflags="-s -w" -o bin/arlon main.go
 
 cluster-config:
 	mkdir -p bin
@@ -77,16 +77,16 @@ cluster-config:
 
 # goreleaser can invoke this target to produce binaries for different OS and CPU arch combinations
 build-cli: fmt vet ## Build CLI binary (with the current OS and CPU architecture) from the go env.
-	go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
+	go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
 
 build-cli-linux: fmt vet ## Build CLI binary for Linux
-	GOOS=linux GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
 
 build-cli-mac-amd64: fmt vet ## Build CLI binary for Mac (AMD/ Intel CPU)
-	GOOS=darwin GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
+	GOOS=darwin GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
 
 build-cli-mac-arm64: fmt vet ## Build CLI binary for Mac (Apple Silicon)
-	GOOS=darwin GOARCH=arm64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
+	GOOS=darwin GOARCH=arm64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
 
 ifeq (GOARCH,"arm64")
 build-cli-mac: build-cli-mac-arm64
@@ -96,7 +96,7 @@ endif
 
 # Arlon has not been tested on Windows yet.
 build-cli-win: fmt vet ## Build CLI binary for Windows.
-	GOOS=windows GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
+	GOOS=windows GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REPO_ORG ?= arlonproj
 REPO_NAME ?= arlon
 CAPI_VERSION := $(shell cat $(REPO_ROOT)$*/capirc)
 CAPI_LD_FLAG := -X github.com/arlonproj/arlon/cmd/install.capiCoreProvider=$(CAPI_VERSION)
-LD_FLAGS := $(CAPI_LD_FLAG)
+LD_FLAGS := $(CAPI_LD_FLAG) -s -w
 # Image URL to use all building/pushing image targets
 IMG ?= $(REPO_SERVER)/$(REPO_ORG)/$(REPO_NAME)/controller:$(VERSION)
 # Produce CRDs with multiversion enabled for v1 APIs - fixes failure in make test
@@ -77,16 +77,16 @@ cluster-config:
 
 # goreleaser can invoke this target to produce binaries for different OS and CPU arch combinations
 build-cli: fmt vet ## Build CLI binary (with the current OS and CPU architecture) from the go env.
-	go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
+	go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
 
 build-cli-linux: fmt vet ## Build CLI binary for Linux
-	GOOS=linux GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
 
 build-cli-mac-amd64: fmt vet ## Build CLI binary for Mac (AMD/ Intel CPU)
-	GOOS=darwin GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
+	GOOS=darwin GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
 
 build-cli-mac-arm64: fmt vet ## Build CLI binary for Mac (Apple Silicon)
-	GOOS=darwin GOARCH=arm64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
+	GOOS=darwin GOARCH=arm64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
 
 ifeq (GOARCH,"arm64")
 build-cli-mac: build-cli-mac-arm64
@@ -96,7 +96,7 @@ endif
 
 # Arlon has not been tested on Windows yet.
 build-cli-win: fmt vet ## Build CLI binary for Windows.
-	GOOS=windows GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS) -s -w' main.go
+	GOOS=windows GOARCH=amd64 go build -o bin/arlon -ldflags '$(LD_FLAGS)' main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go


### PR DESCRIPTION
#### On Unix based systems, the debugging information in the executables can be reduced by building it with "-w" and "-s" flags. This reduces the binary size.