### PR TITLE
Use ignoreDifferences in AWSMachineTemplate.Spec to avoid out-of-sync baseclusters

### DIFF
--- a/docs/baseclusters.md
+++ b/docs/baseclusters.md
@@ -193,4 +193,7 @@ yet have an exhaustive list).
 - Changing the Kubernetes version of the control plane or data plane *is* supported, so long as the new version
 is supported by the relevant providers. If accepted, such a change will result in a rolling update
 of the corresponding plane.
+- Specific to AWS: the `AWSMachineTemplate.spec` is immutable and a CAPI webhook disallows such updates. The user is advised to not make such modifications to a basecluster manifest.
+In the event that such an event does happen, the user is advised to not manually sync in those changes via `argocd`. If a new cluster with a different `AWSMachineTemplate.spec` is desired,
+the recommended approach is to make a copy of the manifests in the workspace repository and then issue an `arlon cluster create` command which would then consume this manifest.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -17,7 +17,7 @@ definition of *tool types*. Consequently, the list of supported bundle
 types mirrors ArgoCD's supported set of manifest-producing tools.
 Each bundle is defined using a Kubernetes ConfigMap resource in the arlo namespace.
 Additionally, a bundle can embed the data itself ("static bundle"), or contain a reference
-to the data ("dynamic bundle"). A reference can be a URL, github location, or Helm repo location.
+to the data ("dynamic bundle"). A reference can be a URL, GitHub location, or Helm repo location.
 The current list of supported bundle types is:
 
 * manifest_inline: a single manifest yaml file embedded in the resource
@@ -31,7 +31,7 @@ The current list of supported bundle types is:
 Bundles can specify an optional *purpose* to help classify and organize them.
 In the future, Arlo may order bundle installation by purpose order (for e.g.
 install bundles with purpose=*networking* before others) but that is not the
-case today. The currenty *suggested* purpose values are:
+case today. The currently *suggested* purpose values are:
 - networking
 - add-on
 - data-service
@@ -75,7 +75,7 @@ management cluster.
 
 Here is a summary of the kinds of resources generated and deployed by the chart:
 - A unique namespace with a name based on the cluster's name. All subsequent
-  resources below are created inside of that namespace.
+  resources below are created inside that namespace.
 - The stack-specific resources to create the cluster (for e.g. Cluster API resources)
 - A ClusterRegistration to automatically register the cluster with ArgoCD
 - A GitRepoDir to automatically create a git repo and/or directory to host a copy

--- a/pkg/cluster/cluster_app.go
+++ b/pkg/cluster/cluster_app.go
@@ -85,13 +85,19 @@ func constructClusterApp(
 	})
 
 	ignoreDiffs = append(ignoreDiffs, argoappv1.ResourceIgnoreDifferences{
-		Group:        "infrastructure.cluster.x-k8s.io/v1beta1",
+		Group:        "infrastructure.cluster.x-k8s.io",
 		Kind:         "AWSMachineTemplate",
 		JSONPointers: []string{"/spec"},
 	})
 	app.Spec.IgnoreDifferences = ignoreDiffs
 	app.Spec.Source.Kustomize = &argoappv1.ApplicationSourceKustomize{
 		NamePrefix: clusterName + "-",
+	}
+	app.Spec.SyncPolicy = &argoappv1.SyncPolicy{
+		Automated: &argoappv1.SyncPolicyAutomated{
+			Prune: true,
+		},
+		SyncOptions: []string{"Prune=true", "RespectIgnoreDifferences=true"},
 	}
 	app.Spec.Source.RepoURL = repoUrl
 	app.Spec.Source.TargetRevision = repoRevision

--- a/pkg/cluster/cluster_app.go
+++ b/pkg/cluster/cluster_app.go
@@ -83,6 +83,12 @@ func constructClusterApp(
 		Kind:         "AWSManagedControlPlane",
 		JSONPointers: []string{"/spec/version"},
 	})
+
+	ignoreDiffs = append(ignoreDiffs, argoappv1.ResourceIgnoreDifferences{
+		Group:        "infrastructure.cluster.x-k8s.io/v1beta1",
+		Kind:         "AWSMachineTemplate",
+		JSONPointers: []string{"/spec"},
+	})
 	app.Spec.IgnoreDifferences = ignoreDiffs
 	app.Spec.Source.Kustomize = &argoappv1.ApplicationSourceKustomize{
 		NamePrefix: clusterName + "-",


### PR DESCRIPTION
Fixes #137 
- Use ignore difference rule for `AWSMachineTemplate.spec`
- Doc changes to mention immutability
## Testing (Manual):
```shell
Every 2.0s: argocd app list                                                                                                                                                                ip-172-31-25-241: Fri Sep 30 06:15:31 2022

NAME                         CLUSTER                         NAMESPACE         PROJECT  STATUS   HEALTH   SYNCPOLICY  CONDITIONS       REPO                                            PATH                       TARGET
cas-121                      https://kubernetes.default.svc  default           default  Synced   Healthy  Auto-Prune  <none>           https://github.com/ShaunakJoshi1407/arlon-demo  clusters/cas-121/mgmt      main
cas-121-calico-dynamic                                       default           default  Unknown  Healthy  Auto-Prune  ComparisonError  https://github.com/ShaunakJoshi1407/arlon-demo  bundles/calico             HEAD
cas-121-profile-prof-calico  https://kubernetes.default.svc  argocd            default  Synced   Healthy  Auto-Prune  <none>           https://github.com/ShaunakJoshi1407/arlon-demo  profiles/prof-calico/mgmt  HEAD
not-that-cluster             https://kubernetes.default.svc  not-that-cluster  default  Synced   Healthy  Auto-Prune  <none>           https://github.com/Rohitrajak1807/arln-oss.git  clusters/that-cluster      main
not-that-cluster-arlon       https://kubernetes.default.svc  default           default  Synced   Healthy  Auto-Prune  <none>           https://github.com/arlonproj/arlon.git          pkg/cluster/manifests      v0.9.0
that-cluster                 https://kubernetes.default.svc  that-cluster      default  Synced   Healthy  Auto-Prune  <none>           https://github.com/Rohitrajak1807/arln-oss.git  clusters/that-cluster      main
that-cluster-arlon           https://kubernetes.default.svc  default           default  Synced   Healthy  Auto-Prune  <none>           https://github.com/arlonproj/arlon.git          pkg/cluster/manifests      v0.9.0
```
- `that-cluster` consumes the manifests at `clusters/that-cluster`.
- The `AWSMachineTemplate.spec` is then edited and pushed to the git repository.
- `not-that-cluster` is deployed using this modified manifest and put under observation for around 8 hours
- Both these clusters are shown to be healthy and synced