### PR TITLE
fix #248 - support for several AWS MachinePool types

### DIFF
--- a/pkg/basecluster/data.go
+++ b/pkg/basecluster/data.go
@@ -19,6 +19,10 @@ nameReference:
     kind: MachineDeployment
   - path: spec/template/spec/clusterName
     kind: MachineDeployment
+  - path: spec/clusterName
+    kind: MachinePool
+  - path: spec/template/spec/clusterName
+    kind: MachinePool
 - kind: AWSCluster
   group: infrastructure.cluster.x-k8s.io
   version: v1beta1
@@ -91,4 +95,10 @@ nameReference:
     kind: MachineDeployment
   - path: spec/machineTemplate/infrastructureRef/name
     kind: KubeadmControlPlane
+- kind: AWSManagedMachinePool
+  group: infrastructure.cluster.x-k8s.io
+  version: v1beta1
+  fieldSpecs:
+  - path: spec/template/spec/infrastructureRef/name
+    kind: MachinePool
 `

--- a/pkg/basecluster/data.go
+++ b/pkg/basecluster/data.go
@@ -101,4 +101,10 @@ nameReference:
   fieldSpecs:
   - path: spec/template/spec/infrastructureRef/name
     kind: MachinePool
+- kind: AWSMachinePool
+  group: infrastructure.cluster.x-k8s.io
+  version: v1beta1
+  fieldSpecs:
+  - path: spec/template/spec/infrastructureRef/name
+    kind: MachinePool
 `


### PR DESCRIPTION
Fixes #248. Both flavors of AWS MachinePools - AWSMachinePool and AWSManagedMachinePool - were broken due to missing entries in the name reference configuration.

Testing (manual): successfully deployed EKS cluster with AWSManagedMachinePool node groups as part of Spot.io Ocean integration demo: https://youtu.be/Hy5GXWV_b2M