### PR TITLE
Lift sudo requirements from `arlon install`

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -50,7 +50,12 @@ func NewCommand() *cobra.Command {
 		Short:             "Install required tools for Arlon",
 		Long:              "Install kubectl, Argocd cli, check git cli, and install compatible CAPI version on the management cluster",
 		DisableAutoGenTag: true,
-		Example:           "arlon install --kubectlPath <string> --argocdPath <string> --kubeconfigPath /path/to/kubeconfig",
+		Example: `arlon install --kubectlPath <string> --argocdPath <string> --kubeconfigPath /path/to/kubeconfig # install CAPI core provider and CLI tools, with the given argocd path and kubeconfig path
+				  arlon install # installs CLI tools and CAPI
+				  arlon install --tools-only # installs only the CLI tools
+				  arlon install --capi-only # installs only CAPI
+				  arlon install --capi-only --infrastructure aws # installs CAPA provider on the management cluster
+		`,
 		RunE: func(c *cobra.Command, args []string) error {
 			// Install kubectl and point it to the kubeconfig
 			isCapiOnly, _ := strconv.ParseBool(c.Flag("capi-only").Value.String())

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"runtime"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"strconv"
 	"time"
 
 	"github.com/arlonproj/arlon/pkg/log"
@@ -40,6 +41,10 @@ var (
 )
 
 func NewCommand() *cobra.Command {
+	var (
+		toolsOnly bool
+		capiOnly  bool
+	)
 	command := &cobra.Command{
 		Use:               "install",
 		Short:             "Install required tools for Arlon",
@@ -47,42 +52,24 @@ func NewCommand() *cobra.Command {
 		DisableAutoGenTag: true,
 		Example:           "arlon install --kubectlPath <string> --argocdPath <string> --kubeconfigPath /path/to/kubeconfig",
 		RunE: func(c *cobra.Command, args []string) error {
-			fmt.Println("Note: SUDO access is required to install the required tools for Arlon")
-			fmt.Println()
-			var err error
 			// Install kubectl and point it to the kubeconfig
-			_, err = installKubectl()
-			if err == ErrKubectlPresent {
-				fmt.Println(Green("✓") + " kubectl is already present at default(" + Red(defaultKubectlPath) + ")location or user specifed location")
-			} else if err != nil {
-				fmt.Println(Red("x ")+"Error while installing kubectl ", err)
-			} else {
-				fmt.Println(Green("✓") + " Successfully installed kubectl")
+			isCapiOnly, _ := strconv.ParseBool(c.Flag("capi-only").Value.String())
+			isToolsOnly, _ := strconv.ParseBool(c.Flag("tools-only").Value.String())
+			if !isToolsOnly && !isCapiOnly { // none of these flags were set, so set to true and install both
+				isToolsOnly = true
+				isCapiOnly = true
 			}
-
-			fmt.Println()
-			_, err = verifyGit()
-			if err == ErrGitPresent {
-				fmt.Println(Green("✓") + " git is already present in the path")
-			} else {
-				fmt.Println(Yellow("! ") + "Install git cli")
-			}
-
-			fmt.Println()
-			_, err = installArgoCD()
-			if err == ErrArgoCDPresent {
-				fmt.Println(Green("✓") + " argocd is already present at default(" + Red(defaultArgocdPath) + ")location or user specifed location")
-			} else if err != nil {
-				fmt.Println(Red("x ")+"Error while installing argocd ", err)
-			} else {
-				fmt.Println(Green("✓") + " Successfully installed argocd")
+			if isToolsOnly {
+				installCLITools()
 			}
 			fmt.Println()
-			fmt.Printf("Attempting to install %s with infrastructure providers %v and bootstrap providers %v\n", capiCoreProvider, infraProviders, bootstrapProviders)
-			if err := installCAPI(capiCoreProvider, infraProviders, bootstrapProviders); err != nil {
-				return err
+			if isCapiOnly {
+				fmt.Printf("Attempting to install %s with infrastructure providers %v and bootstrap providers %v\n", capiCoreProvider, infraProviders, bootstrapProviders)
+				if err := installCAPI(capiCoreProvider, infraProviders, bootstrapProviders); err != nil {
+					return err
+				}
+				fmt.Printf("%s CAPI is installed...\n", Green("✓"))
 			}
-			fmt.Printf("%s CAPI is installed...\n", Green("✓"))
 			return nil
 		},
 	}
@@ -91,8 +78,39 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&kubeconfigPath, "kubeconfigPath", "", "kubeconfig path for the management cluster")
 	command.Flags().StringSliceVar(&infraProviders, "infrastructure", nil, "comma separated list of infrastructure provider components to install alongside CAPI")
 	command.Flags().StringSliceVar(&bootstrapProviders, "bootstrap", nil, "bootstrap provider components to add to the management cluster")
-	_ = command.MarkFlagRequired("kubeconfigPath")
+	command.Flags().BoolVarP(&toolsOnly, "tools-only", "t", false, "set this flag to install only CLI tools")
+	command.Flags().BoolVarP(&capiOnly, "capi-only", "c", false, "set this flag to install only CAPI on the management cluster")
+	command.MarkFlagsMutuallyExclusive("tools-only", "capi-only")
 	return command
+}
+
+func installCLITools() {
+	_, err := installKubectl()
+	if err == ErrKubectlPresent {
+		fmt.Println(Green("✓") + " kubectl is already present at default(" + Red(defaultKubectlPath) + ")location or user specifed location")
+	} else if err != nil {
+		fmt.Println(Red("x ")+"Error while installing kubectl ", err)
+	} else {
+		fmt.Println(Green("✓") + " Successfully installed kubectl")
+	}
+
+	fmt.Println()
+	_, err = verifyGit()
+	if err == ErrGitPresent {
+		fmt.Println(Green("✓") + " git is already present in the path")
+	} else {
+		fmt.Println(Yellow("! ") + "Install git cli")
+	}
+
+	fmt.Println()
+	_, err = installArgoCD()
+	if err == ErrArgoCDPresent {
+		fmt.Println(Green("✓") + " argocd is already present at default(" + Red(defaultArgocdPath) + ")location or user specifed location")
+	} else if err != nil {
+		fmt.Println(Red("x ")+"Error while installing argocd ", err)
+	} else {
+		fmt.Println(Green("✓") + " Successfully installed argocd")
+	}
 }
 
 // Check if kubectl is installed and if not then install kubectl
@@ -175,7 +193,7 @@ func installKubectlPlatform() error {
 			fmt.Println(" → Error installing the latest kubectl version")
 			return err
 		}
-		_, err = exec.Command("chmod", "+x", kubectlPath).Output()
+		_, err = exec.Command("sudo", "chmod", "+x", kubectlPath).Output()
 		if err != nil {
 			fmt.Println(" → Error giving execute permission to kubectl")
 			return err
@@ -198,7 +216,7 @@ func downloadKubectlLatest(osPlatform string) error {
 	} else {
 		downloadKubectl = "https://storage.googleapis.com/kubernetes-release/release/" + string(ver) + "/bin/" + osPlatform + "/amd64/kubectl"
 	}
-	_, err = exec.Command("curl", "-o", kubectlPath, "-LO", downloadKubectl).Output()
+	_, err = exec.Command("sudo", "curl", "-o", kubectlPath, "-LO", downloadKubectl).Output()
 	if err != nil {
 		return err
 	}
@@ -226,7 +244,7 @@ func installArgoCDPlatform() error {
 		if err != nil {
 			fmt.Println(" → Error installing the latest argocd version")
 		}
-		_, err = exec.Command("chmod", "+x", argocdPath).Output()
+		_, err = exec.Command("sudo", "chmod", "+x", argocdPath).Output()
 		if err != nil {
 			fmt.Println(" → Error giving execute permission to argocd (ArgoCD CLI)")
 			return err
@@ -244,7 +262,7 @@ func downloadArgoCD(osPlatform string) error {
 	} else {
 		downloadArgoCD = "https://github.com/argoproj/argo-cd/releases/download/" + argocdVersion + "/argocd-" + osPlatform + "-amd64"
 	}
-	_, err := exec.Command("curl", "-o", argocdPath, "-LO", downloadArgoCD).Output()
+	_, err := exec.Command("sudo", "curl", "-o", argocdPath, "-LO", downloadArgoCD).Output()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
install command has optional switches to install just the CLI tools or CAPI (defaults to both), the command doesn't need to be run as `sudo arlon install`. Privileges are asked when needed.
Fix #302 