### PR TITLE
Add version and version check command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ REPO_ORG ?= arlonproj
 REPO_NAME ?= arlon
 CAPI_VERSION := $(shell cat $(REPO_ROOT)$*/capirc)
 ARGO_VERSION := $(shell cat $(REPO_ROOT)$*/argorc)
+ARLON_CLI_VERSION := $(shell cat $(REPO_ROOT)$*/version)
 CAPI_LD_FLAG := -X github.com/arlonproj/arlon/cmd/install.capiCoreProvider=$(CAPI_VERSION)
 ARGO_LD_FLAG := -X github.com/arlonproj/arlon/cmd/initialize.argocdGitTag=$(ARGO_VERSION)
-LD_FLAGS := $(CAPI_LD_FLAG) $(ARGO_LD_FLAG) -s -w
+ARLON_CLI_LD_FLAG := -X github.com/arlonproj/arlon/cmd/version.cliVersion=$(ARLON_CLI_VERSION)
+LD_FLAGS := $(CAPI_LD_FLAG) $(ARGO_LD_FLAG) $(ARLON_CLI_LD_FLAG) -s -w
 # Image URL to use all building/pushing image targets
 IMG ?= $(REPO_SERVER)/$(REPO_ORG)/$(REPO_NAME)/controller:$(VERSION)
 # Produce CRDs with multiversion enabled for v1 APIs - fixes failure in make test

--- a/cmd/version/check.go
+++ b/cmd/version/check.go
@@ -1,0 +1,1 @@
+package version

--- a/cmd/version/check.go
+++ b/cmd/version/check.go
@@ -17,7 +17,6 @@ func check() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := http.Client{Timeout: time.Minute * 3}
 			reqUrl := fmt.Sprintf("https://raw.githubusercontent.com/arlonproj/arlon/v%s/version", strings.Join(strings.Split(cliVersion, ".")[:2], "."))
-			fmt.Println(reqUrl)
 			req, err := http.NewRequest(http.MethodGet, reqUrl, nil)
 			if err != nil {
 				return err

--- a/cmd/version/check.go
+++ b/cmd/version/check.go
@@ -42,10 +42,10 @@ func check() *cobra.Command {
 				return err
 			}
 			if ver.Compare(currentVersion) == 1 {
-				fmt.Printf("CLI version %s is outdated. New patch %s available\n", cliVersion, ver.String())
+				fmt.Printf("Arlon CLI version %s is outdated. New patch %s available\n", cliVersion, ver.String())
 				return nil
 			}
-			fmt.Printf("CLI version %s Upto date\n", cliVersion)
+			fmt.Printf("Arlon CLI version %s up-to-date\n", cliVersion)
 			return nil
 		},
 	}

--- a/cmd/version/check.go
+++ b/cmd/version/check.go
@@ -1,1 +1,53 @@
 package version
+
+import (
+	"fmt"
+	"github.com/blang/semver"
+	"github.com/spf13/cobra"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func check() *cobra.Command {
+	return &cobra.Command{
+		Use:   "check",
+		Short: "Check for a patch for the CLI",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := http.Client{Timeout: time.Minute * 3}
+			reqUrl := fmt.Sprintf("https://raw.githubusercontent.com/arlonproj/arlon/v%s/version", strings.Join(strings.Split(cliVersion, ".")[:2], "."))
+			fmt.Println(reqUrl)
+			req, err := http.NewRequest(http.MethodGet, reqUrl, nil)
+			if err != nil {
+				return err
+			}
+			res, err := client.Do(req)
+			if err != nil {
+				return err
+			}
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(res.Body)
+			version, err := io.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
+			latestVersion := strings.TrimSpace(string(version))
+			ver, err := semver.Parse(latestVersion)
+			if err != nil {
+				return err
+			}
+			currentVersion, err := semver.Parse(cliVersion)
+			if err != nil {
+				return err
+			}
+			if ver.Compare(currentVersion) == 1 {
+				fmt.Printf("CLI version %s is outdated. New patch %s available\n", cliVersion, ver.String())
+				return nil
+			}
+			fmt.Printf("CLI version %s Upto date\n", cliVersion)
+			return nil
+		},
+	}
+}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -15,5 +15,6 @@ func NewCommand() *cobra.Command {
 			fmt.Printf("CLI Version: %s\n", cliVersion)
 		},
 	}
+	cmd.AddCommand(check())
 	return cmd
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -12,7 +12,7 @@ func NewCommand() *cobra.Command {
 		Use:   "version",
 		Short: "check for arlon CLI version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("CLI Version: %s\n", cliVersion)
+			fmt.Printf("Arlon CLI Version: %s\n", cliVersion)
 		},
 	}
 	cmd.AddCommand(check())

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,19 @@
+package version
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var cliVersion string
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "check for arlon CLI version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("CLI Version: %s\n", cliVersion)
+		},
+	}
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 
 require (
 	github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/stretchr/testify v1.8.1
@@ -63,7 +64,6 @@ require (
 	github.com/argoproj/notifications-engine v0.3.1-0.20220430155844-567361917320 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bombsimon/logrusr/v2 v2.0.1 // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4 // indirect
 	github.com/casbin/casbin/v2 v2.39.1 // indirect

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"github.com/arlonproj/arlon/cmd/initialize"
 	"os"
 
 	"github.com/arlonproj/arlon/cmd/basecluster"
@@ -28,10 +27,12 @@ import (
 	"github.com/arlonproj/arlon/cmd/clusterspec"
 	"github.com/arlonproj/arlon/cmd/controller"
 	"github.com/arlonproj/arlon/cmd/gitrepo"
+	"github.com/arlonproj/arlon/cmd/initialize"
 	"github.com/arlonproj/arlon/cmd/install"
 	"github.com/arlonproj/arlon/cmd/list_clusters"
 	"github.com/arlonproj/arlon/cmd/profile"
 	"github.com/arlonproj/arlon/cmd/verify"
+	"github.com/arlonproj/arlon/cmd/version"
 	"github.com/arlonproj/arlon/cmd/webhook"
 	"github.com/spf13/cobra"
 
@@ -69,13 +70,14 @@ func main() {
 	command.AddCommand(verify.NewCommand())
 	command.AddCommand(install.NewCommand())
 	command.AddCommand(initialize.NewCommand())
+	command.AddCommand(version.NewCommand())
 
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	// override default log level, which is initially set to 'debug'
-	flag.Set("zap-log-level", "info")
+	_ = flag.Set("zap-log-level", "info")
 	flag.Parse()
 	logger := zap.New(zap.UseFlagOptions(&opts))
 	ctrl.SetLogger(logger)


### PR DESCRIPTION
Fix #61 
Add version command to get current version
Add version check command to get the latest patch (won't work on main branch or a version X.Y.Z for which the vX.Y branch doesn't exist)