### PR TITLE
Backport to v0.3 : Fix #238: Set RootFS ReadOnly False (#239)

### DIFF
--- a/deploy/manifests/deploy.yaml
+++ b/deploy/manifests/deploy.yaml
@@ -55,8 +55,9 @@ spec:
           capabilities:
             drop:
             - all
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
+          runAsUser: 0
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:


### PR DESCRIPTION
Fixes #238 for v0.3 (needs backport since this was merged in main only recently - much after v0.3 branched off)
Has been backported to v0.9 already

Aha! Link: https://pf9.aha.io/features/ARLON-333