### PR TITLE
Update GitHub Actions for higher rate limit in setup-go action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
       uses: actions/setup-go@v3
       with:
         token: ${{ secrets.GH_PAT }}
-        go-version: 1.19.3
+        go-version: 1.19
         check-latest: true
         cache: true
+    - name: Print the version of golang
+      run: go version
     - name: Build
       run: go build -v ./...
     - name: Unit tests
@@ -39,6 +41,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          token: ${{ secrets.GH_PAT }}
+          check-latest: true
           cache: 'pip' # caching pip dependencies
+          cache-dependency-path: '**/requirements.txt'
       - run: pip install -r docs/requirements.txt
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build:
+    environment: arlon
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
+        token: ${{ secrets.GH_PAT }}
         go-version: 1.19.3
         check-latest: true
         cache: true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,9 +31,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           token: ${{ secrets.GH_PAT }}
-          go-version: 1.19.3
+          go-version: 1.19
           check-latest: true
-          cache: true
+      -
+        name: Print the version of golang
+        run: |
+          go version
       -
         name: Cache go modules
         uses: actions/cache@v3

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,7 +30,10 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
+          token: ${{ secrets.GH_PAT }}
           go-version: 1.19.3
+          check-latest: true
+          cache: true
       -
         name: Cache go modules
         uses: actions/cache@v3

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -20,7 +20,10 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
+          token: ${{ secrets.GH_PAT }}        
           go-version: 1.19.3
+          check-latest: true
+          cache: true          
       -
         name: Cache go modules
         uses: actions/cache@v3

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -21,9 +21,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           token: ${{ secrets.GH_PAT }}        
-          go-version: 1.19.3
+          go-version: 1.19
           check-latest: true
-          cache: true          
+      -
+        name: Print the version of golang
+        run: |
+          go version
       -
         name: Cache go modules
         uses: actions/cache@v3


### PR DESCRIPTION
```
To get a higher rate limit, you can [generate a personal access token on github.com](https://github.com/settings/tokens/new) and pass it as the token input for the action:
```
Reference: https://github.com/actions/setup-go#using-setup-go-on-ghes

Aha! Link: https://pf9.aha.io/features/ARLON-336