### PR TITLE
Update init.go - Bump defaultK8sVersion from 1.23.11 to 1.23.14

### DIFF
--- a/cmd/initialize/init.go
+++ b/cmd/initialize/init.go
@@ -62,7 +62,7 @@ const (
 	baseclusterDir                         = "baseclusters"
 	defaultCtrlPlaneCount            int64 = 2
 	defaultWorkerCount               int64 = 3
-	defaultK8sVersion                      = "1.23.11"
+	defaultK8sVersion                      = "1.23.14"
 )
 
 type porfForwardCfg struct {


### PR DESCRIPTION
Bump defaultK8sVersion from 1.23.11 to 1.23.14

Refer https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md 