### PR TITLE
Init command fixes

### DIFF
--- a/cmd/initialize/init.go
+++ b/cmd/initialize/init.go
@@ -62,9 +62,9 @@ const (
 	argoServer                                       = "127.0.0.1:8080"
 	exampleDir                                       = "examples"
 	baseclusterDir                                   = "baseclusters"
-	defaultCtrlPlaneCount                      int64 = 2
+	defaultCtrlPlaneCount                      int64 = 3
 	defaultWorkerCount                         int64 = 3
-	defaultK8sVersion                                = "1.23.14"
+	defaultK8sVersion                                = "v1.23.14"
 )
 
 type porfForwardCfg struct {

--- a/pkg/install/aws.go
+++ b/pkg/install/aws.go
@@ -71,10 +71,12 @@ func (a *awsInstaller) EnsureRequisites() error {
 					Message:  fmt.Sprintf("%s environment variable not set", env.name),
 				}
 			}
-			if !a.recoverOnFail(env.msg) {
-				return &ErrBootstrap{
-					HardFail: true,
-					Message:  fmt.Sprintf("%s environment variable not set", env.name),
+			if !a.silence {
+				if !a.recoverOnFail(env.msg) {
+					return &ErrBootstrap{
+						HardFail: true,
+						Message:  fmt.Sprintf("%s environment variable not set", env.name),
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- k8s version needs a v prefix
- etcd health requires odd master nodes
- -y flag still prompts for AWS_SESSION_TOKEN

Fix: #370 
Fix: #371 
Fix: #372 