### PR TITLE
Backport to v0.9  : docs versioning

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,6 @@
 mkdocs==1.4.2
-mkdocs-material==8.5.7
+mkdocs-material==8.5.11
+pymdown-extensions==9.9
+mkdocs_pymdownx_material_extras==2.3.1
+mkdocs-minify-plugin==0.6.2
+mike==1.1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,34 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 
+plugins:
+  - search
+  - mkdocs_pymdownx_material_extras
+
+extra:
+  version:
+    default: stable
+    provider: mike
+
+extra_javascript:
+  - https://unpkg.com/mermaid@8.8.4/dist/mermaid.min.js
+  
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - pymdownx.striphtml:
+      strip_comments: true
+      strip_js_on_attributes: false
+  - pymdownx.superfences:
+      custom_fences:
+        # Mermaid diagrams
+        - name: diagram
+          class: diagram
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - toc:
+      permalink: true
+      
 nav:
     - Home: 'README.md'
     - Design: 'design.md'

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %}


### PR DESCRIPTION
* Issue #357: versioned docs: Add Mike and make it snow too

This has been setup by following https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#versioning 

We will push three versions using Mike by following https://github.com/squidfunk/mkdocs-material-example-versioning 
- 0.3
- 0.9
- latest

We can setup aliases like latest for 0.10 (main at the moment), stable for 0.9