### PR TITLE
Resolved the issue where patch file can't point to a resource based on a name

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -36,7 +36,7 @@ func createClusterCommand() *cobra.Command {
 	var patchRepoRevision string
 	var clusterRepoPath string
 	var clusterName string
-	var overridesDir string
+	var overridesPath string
 	var outputYaml bool
 	var profileName string
 	var gen2CASEnabled bool //gen2 specific flag to enable cluster autoscaler
@@ -63,14 +63,14 @@ func createClusterCommand() *cobra.Command {
 				return fmt.Errorf("failed to get repository credentials: %s", err)
 			}
 			overridden := false
-			if overridesDir != "" {
+			if overridesPath != "" {
 				_, err = appIf.Get(context.Background(),
 					&argoapp.ApplicationQuery{Name: &clusterName})
 				if err == nil {
 					return fmt.Errorf("arlon cluster already exists")
 				}
 				err = cluster.CreatePatchDir(config, clusterName, patchRepoUrl, argocdNs,
-					patchRepoPath, patchRepoRevision, clusterRepoRevision, overridesDir, clusterRepoUrl, clusterRepoPath)
+					patchRepoPath, patchRepoRevision, clusterRepoRevision, overridesPath, clusterRepoUrl, clusterRepoPath)
 				if err != nil {
 					return fmt.Errorf("failed to create patch files directory: %s", err)
 				}
@@ -168,7 +168,7 @@ func createClusterCommand() *cobra.Command {
 	command.Flags().StringVar(&patchRepoRevision, "patch-repo-revision", "main", "the git revision for patch files")
 	command.Flags().StringVar(&clusterRepoPath, "repo-path", "", "the git repository path for cluster template")
 	command.Flags().StringVar(&clusterName, "cluster-name", "", "the cluster name")
-	command.Flags().StringVar(&overridesDir, "overrides-dir", "", "path to the corresponding patch file to the cluster")
+	command.Flags().StringVar(&overridesPath, "overrides-path", "", "path to the corresponding patch file to the cluster")
 	command.Flags().BoolVar(&outputYaml, "output-yaml", false, "output root applications YAML instead of deploying to ArgoCD")
 	command.Flags().StringVar(&profileName, "profile", "", "profile name (if specified, must refer to dynamic profile)")
 	command.Flags().BoolVar(&gen2CASEnabled, "autoscaler", false, "enable CAPI cluster autoscaler for cluster template based clusters")

--- a/docs/gen2_Tutorial.md
+++ b/docs/gen2_Tutorial.md
@@ -375,24 +375,35 @@ arlon cluster create --cluster-name <clusterName> --repo-alias prod --repo-path 
 
 We call the concept of constructing various clusters with patches from the same base manifest as cluster overrides. 
 The cluster overrides feature is built on top of the existing base cluster design. So, A user can create a cluster from the base manifest using the same command as in the above step(gen2 cluster creation).
-Now, to create a cluster with overrides in the base manifest, a user should have the corresponding patch files in a dedicated folder in local which doesn't contain any other files except patch files. Example of a patch file where we want to override replicas count to 2 is:
+Now, to create a cluster with overrides in the base manifest, a user should have the corresponding patch files in a single yaml file in local. Example of a patch file where we want to override replicas count to 2 is and change the sshkeyname:
 
 ```shell
-  ---
-  apiVersion: cluster.x-k8s.io/v1beta1
-  kind: MachineDeployment
-  metadata:
-    name: .*
-  spec:
-    replicas: 2
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: capi-quickstart-eks-md-0
+spec:
+  replicas: 2
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: AWSManagedControlPlane
+metadata:
+  name: capi-quickstart-eks-control-plane
+spec:
+  sshKeyName: random
+---
+
   ```
+
+Note: The metadata field in the patch file should be same as of the metadata field in the resources file.
 
 Refer to this [document](https://blog.scottlowe.org/2019/11/12/using-kustomize-with-cluster-api-manifests/) to know more about patch files
 
 Command to create a gen2 workload cluster form the base cluster manifest with overrides to the manifest is:
 
 ```shell
-arlon cluster create <cluster-name> --repo-url <repo url where base manifest is present> --repo-path <repo path to the base manifest> --override <path to the patch files folder> --patch-repo-url <repo url where patch files should be stored> --patch-repo-path <repo path to store the patch files>
+arlon cluster create <cluster-name> --repo-url <repo url where base manifest is present> --repo-path <repo path to the base manifest> --overrides-path <path to the patch files folder> --patch-repo-url <repo url where patch files should be stored> --patch-repo-path <repo path to store the patch files>
 ````
 Runnning the above command will create a cluster named folder in patch repo path of patch repo url which contains the patch files, kustomization.yaml and configurations.yaml which are used to create the cluster app.
 

--- a/docs/gen2_Tutorial.md
+++ b/docs/gen2_Tutorial.md
@@ -375,7 +375,7 @@ arlon cluster create --cluster-name <clusterName> --repo-alias prod --repo-path 
 
 We call the concept of constructing various clusters with patches from the same base manifest as cluster overrides. 
 The cluster overrides feature is built on top of the existing base cluster design. So, A user can create a cluster from the base manifest using the same command as in the above step(gen2 cluster creation).
-Now, to create a cluster with overrides in the base manifest, a user should have the corresponding patch files in a single yaml file in local. Example of a patch file where we want to override replicas count to 2 is and change the sshkeyname:
+Now, to create a cluster with overrides in the base manifest, a user should have the corresponding patch files in a single yaml file in local. Here is an example of a patch file where we want to override replicas count to 2 and change the sshkeyname:
 
 ```shell
 ---
@@ -403,7 +403,7 @@ Refer to this [document](https://blog.scottlowe.org/2019/11/12/using-kustomize-w
 Command to create a gen2 workload cluster form the base cluster manifest with overrides to the manifest is:
 
 ```shell
-arlon cluster create <cluster-name> --repo-url <repo url where base manifest is present> --repo-path <repo path to the base manifest> --overrides-path <path to the patch files folder> --patch-repo-url <repo url where patch files should be stored> --patch-repo-path <repo path to store the patch files>
+arlon cluster create <cluster-name> --repo-url <repo url where base manifest is present> --repo-path <repo path to the base manifest> --overrides-path <path to the patch file> --patch-repo-url <repo url where patch file should be stored> --patch-repo-path <repo path to store the patch file>
 ````
 Runnning the above command will create a cluster named folder in patch repo path of patch repo url which contains the patch files, kustomization.yaml and configurations.yaml which are used to create the cluster app.
 

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -109,7 +109,7 @@ func CreatePatchDir(
 	basePath string,
 	patchRepoRevision string,
 	baseRepoRevision string,
-	overridesDir string,
+	overridesPath string,
 	baseRepoUrl string,
 	baseRepoPath string) error {
 	kubeClient, err := kubernetes.NewForConfig(config)
@@ -122,7 +122,7 @@ func CreatePatchDir(
 	}
 
 	err = DeployPatchToGit(creds, argocdNs, clusterName,
-		repoURL, patchRepoRevision, baseRepoRevision, basePath, overridesDir, baseRepoUrl, baseRepoPath)
+		repoURL, patchRepoRevision, baseRepoRevision, basePath, overridesPath, baseRepoUrl, baseRepoPath)
 	if err != nil {
 		return fmt.Errorf("failed to deploy git tree: %s", err)
 	}

--- a/pkg/gitutils/manifests.go
+++ b/pkg/gitutils/manifests.go
@@ -73,6 +73,7 @@ func CopyPatchManifests(wt *gogit.Worktree, filePath string, clusterPath string,
 	if err != nil {
 		return fmt.Errorf("failed to open the patch file %s:", err)
 	}
+	defer src.Close()
 	_, fileName := filepath.Split(filePath)
 	resourcestring := "git::" + baseRepoUrl + "//" + baseRepoPath + "?ref=" + baseRepoRevision
 	kustomizeresult := kustomizeyaml{
@@ -103,23 +104,21 @@ func CopyPatchManifests(wt *gogit.Worktree, filePath string, clusterPath string,
 	if err != nil {
 		return fmt.Errorf("failed to create kustomization.yaml: %s", err)
 	}
+	defer file.Close()
 	err = tmpl.Execute(file, yamlData)
 	if err != nil {
 		return fmt.Errorf("failed to execute kustomization.yaml manifest")
 	}
-	_ = file.Close()
 	if err != nil {
 		return fmt.Errorf("failed to write to kustomization.yaml: %s", err)
 	}
 	dstPath := path.Join(clusterPath, fileName)
 	dst, err := wt.Filesystem.Create(dstPath)
 	if err != nil {
-		_ = src.Close()
 		return fmt.Errorf("failed to create destination file %s: %s", dstPath, err)
 	}
+	defer dst.Close()
 	_, err = io.Copy(dst, src)
-	_ = src.Close()
-	_ = dst.Close()
 	if err != nil {
 		return fmt.Errorf("failed to copy embedded file: %s", err)
 	}

--- a/pkg/gitutils/manifests.go
+++ b/pkg/gitutils/manifests.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -23,17 +22,7 @@ type kustomizeyaml struct {
 	Kind           string   `yaml:"kind"`
 	Resources      []string `yaml:"resources"`
 	Configurations []string `yaml:"configurations"`
-	Patches        []target `yaml:"patches"`
-}
-type target struct {
-	Target info   `yaml:"target"`
-	Path   string `yaml:"path"`
-}
-
-type info struct {
-	Group   string `yaml:"group"`
-	Version string `yaml:"version"`
-	Kind    string `yaml:"kind"`
+	Patches        []string `yaml:"patchesStrategicMerge"`
 }
 
 func CopyManifests(wt *gogit.Worktree, fs embed.FS, root string, mgmtPath string) error {
@@ -79,70 +68,12 @@ func CopyManifests(wt *gogit.Worktree, fs embed.FS, root string, mgmtPath string
 func CopyPatchManifests(wt *gogit.Worktree, filePath string, clusterPath string,
 	baseRepoUrl string, baseRepoPath string, baseRepoRevision string) error {
 	log := log.GetLogger()
-	files, err := ioutil.ReadDir(filePath)
+	src, err := os.OpenFile(filePath, os.O_RDONLY, os.ModePerm)
 	if err != nil {
-		fmt.Println(err)
-		return fmt.Errorf("Failed to read the directory %s", err)
+		return fmt.Errorf("failed to open the patch file %s:", err)
 	}
-	var targetData []target
-	for _, file := range files {
-		newFilePath := path.Join(filePath, file.Name())
-		src, err := os.OpenFile(newFilePath, os.O_RDONLY, os.ModePerm)
-		if err != nil {
-			_ = src.Close()
-			return fmt.Errorf("failed to open patch file %s: %s", filePath, err)
-		}
-
-		kustomFile, err := ioutil.ReadFile(newFilePath)
-		if err != nil {
-			_ = src.Close()
-			return fmt.Errorf("Failed to read the patch file %s", err)
-		}
-		parsedData := make(map[interface{}]interface{})
-
-		err = yaml.Unmarshal(kustomFile, &parsedData)
-		if err != nil {
-			_ = src.Close()
-			return fmt.Errorf("Failed to load the parsed data %s", err)
-		}
-		var targetComp []string
-		var kind string
-		var information info
-		for kustomKey, kustomVal := range parsedData {
-			if kustomKey == "apiVersion" {
-				strKustomVal := fmt.Sprintf("%v", kustomVal)
-				targetComp = strings.Split(string(strKustomVal), "/")
-			}
-			if kustomKey == "kind" {
-				kind = fmt.Sprintf("%v", kustomVal)
-			}
-		}
-		information = info{
-			Group:   string(targetComp[0]),
-			Version: string(targetComp[1]),
-			Kind:    kind,
-		}
-		targetData = append(targetData, target{
-			information, file.Name(),
-		})
-
-		// remove manifests/ prefix
-		components := strings.Split(newFilePath, "/")
-		dstPath := path.Join(components[len(components)-1])
-		dstPath = path.Join(clusterPath, dstPath)
-		dst, err := wt.Filesystem.Create(dstPath)
-		if err != nil {
-			_ = src.Close()
-			return fmt.Errorf("failed to create destination file %s: %s", dstPath, err)
-		}
-		_, err = io.Copy(dst, src)
-		_ = src.Close()
-		_ = dst.Close()
-		if err != nil {
-			return fmt.Errorf("failed to copy embedded file: %s", err)
-		}
-		log.V(1).Info("copied embedded file", "destination", dstPath)
-	}
+	components := strings.Split(filePath, "/")
+	dstPath := path.Join(components[len(components)-1])
 	resourcestring := "git::" + baseRepoUrl + "//" + baseRepoPath + "?ref=" + baseRepoRevision
 	kustomizeresult := kustomizeyaml{
 		APIVersion: "kustomize.config.k8s.io/v1beta1",
@@ -153,10 +84,15 @@ func CopyPatchManifests(wt *gogit.Worktree, filePath string, clusterPath string,
 		Configurations: []string{
 			"configurations.yaml",
 		},
-		Patches: targetData,
+		Patches: []string{
+			components[len(components)-1],
+		},
 	}
 	var tmpl *template.Template
 	yamlData, err := yaml.Marshal(&kustomizeresult)
+	if err != nil {
+		return fmt.Errorf("Failed to marshal the kustomization file: %s", err)
+	}
 	tmpl, err = template.New("kust").Parse(string(yamlData))
 	if err != nil {
 		return fmt.Errorf("failed to create kustomization template: %s", err)
@@ -168,9 +104,25 @@ func CopyPatchManifests(wt *gogit.Worktree, filePath string, clusterPath string,
 		return fmt.Errorf("failed to create kustomization.yaml: %s", err)
 	}
 	err = tmpl.Execute(file, yamlData)
+	if err != nil {
+		return fmt.Errorf("failed to execute kustomization.yaml: %s", err)
+	}
 	_ = file.Close()
 	if err != nil {
 		return fmt.Errorf("failed to write to kustomization.yaml: %s", err)
 	}
+	dstPath = path.Join(clusterPath, dstPath)
+	dst, err := wt.Filesystem.Create(dstPath)
+	if err != nil {
+		_ = src.Close()
+		return fmt.Errorf("failed to create destination file %s: %s", dstPath, err)
+	}
+	_, err = io.Copy(dst, src)
+	_ = src.Close()
+	_ = dst.Close()
+	if err != nil {
+		return fmt.Errorf("failed to copy embedded file: %s", err)
+	}
+	log.V(1).Info("copied embedded file", "destination", dstPath)
 	return nil
 }

--- a/pkg/gitutils/manifests.go
+++ b/pkg/gitutils/manifests.go
@@ -105,7 +105,7 @@ func CopyPatchManifests(wt *gogit.Worktree, filePath string, clusterPath string,
 	}
 	err = tmpl.Execute(file, yamlData)
 	if err != nil {
-		return fmt.Errorf("failed to execute kustomization.yaml manifest: %s", err)
+		return fmt.Errorf("failed to execute kustomization.yaml manifest")
 	}
 	_ = file.Close()
 	if err != nil {


### PR DESCRIPTION
In the present overrides design, a user can't point to a single resource in resources file using the name of resource. The patch gets applied to all the resources irrespective of the name field in patch.yaml. This PR fixes this issue and now, user can  apply a patch to a particular resource using the name field in patch.yaml. Deployed a cluster from the branch and it turned out to be healthy and synced with the patch changes.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/65030629/208578781-0b1f6cf4-1b0d-4d8b-8392-2dd75aac5d5f.png">
