### PR TITLE
CI fixes, using GITHUB_TOKEN, change codecov comment layout and rename basecluster to cluster template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           go-version: 1.19
           check-latest: true
           cache: true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,7 @@ env:
   AWS_CONTROL_PLANE_MACHINE_TYPE: ${{ secrets.AWS_CONTROL_PLANE_MACHINE_TYPE }}
   AWS_NODE_MACHINE_TYPE: ${{ secrets.AWS_NODE_MACHINE_TYPE }}
   AWS_SSH_KEY_NAME: ${{ secrets.AWS_SSH_KEY_NAME }}
-  GITHUB_TOKEN: ${{ secrets.GH_PAT }} # to take care of gh api rate limit when fetching capi provider manifests
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # to take care of gh api rate limit when fetching capi provider manifests
   GIT_USER: ${{ secrets.GIT_USER }}
   GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
   GIT_PASSWORD: ${{ secrets.GIT_PASSWORD }}
@@ -30,7 +30,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           go-version: 1.19
           check-latest: true
       -

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   goreleaser:
     environment: E2E Tests and Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       -
@@ -20,7 +22,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          token: ${{ secrets.GH_PAT }}        
+          token: ${{ secrets.GITHUB_TOKEN }}
           go-version: 1.19
           check-latest: true
       -
@@ -56,7 +58,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/cmd/basecluster/basecluster.go
+++ b/cmd/basecluster/basecluster.go
@@ -5,8 +5,8 @@ import "github.com/spf13/cobra"
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:               "basecluster",
-		Short:             "Manage base clusters",
-		Long:              "Manage base clusters",
+		Short:             "Manage cluster templates",
+		Long:              "Manage cluster templates",
 		Aliases:           []string{"clustertemplate"},
 		DisableAutoGenTag: true,
 		Run: func(c *cobra.Command, args []string) {

--- a/cmd/basecluster/prepare.go
+++ b/cmd/basecluster/prepare.go
@@ -13,8 +13,8 @@ func prepareBaseClusterCommand() *cobra.Command {
 	var casMax int
 	command := &cobra.Command{
 		Use:   "prepare <filename> [flags]",
-		Short: "prepare base cluster",
-		Long:  "prepare base cluster",
+		Short: "prepare cluster template",
+		Long:  "prepare cluster template",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			fileName := args[0]

--- a/cmd/basecluster/preparegit.go
+++ b/cmd/basecluster/preparegit.go
@@ -22,8 +22,8 @@ func prepareGitBaseClusterCommand() *cobra.Command {
 	var casMax int
 	command := &cobra.Command{
 		Use:   "preparegit --repo-url repoUrl [--repo-revision revision] [--repo-path path]",
-		Short: "prepare base cluster directory in git",
-		Long:  "prepare base cluster directory in git",
+		Short: "prepare cluster template directory in git",
+		Long:  "prepare cluster template directory in git",
 		RunE: func(c *cobra.Command, args []string) error {
 			if repoUrl == "" {
 				var err error
@@ -50,17 +50,17 @@ func prepareGitBaseClusterCommand() *cobra.Command {
 			} else {
 				fmt.Println("the files for cluster <",
 					clusterName,
-					"> are already compliant as base cluster, no preparation necessary")
+					"> are already compliant as cluster template, no preparation necessary")
 			}
 			return nil
 		},
 	}
 	clientConfig = cli.AddKubectlFlagsToCmd(command)
 	command.Flags().StringVar(&argocdNs, "argocd-ns", "argocd", "the argocd namespace")
-	command.Flags().StringVar(&repoUrl, "repo-url", "", "the git repository url for base cluster directory")
+	command.Flags().StringVar(&repoUrl, "repo-url", "", "the git repository url for cluster template directory")
 	command.Flags().StringVar(&repoAlias, "repo-alias", gitrepo.RepoDefaultCtx, "git repository alias to use")
-	command.Flags().StringVar(&repoRevision, "repo-revision", "main", "the git revision for base cluster directory")
-	command.Flags().StringVar(&repoPath, "repo-path", "", "the git repository path for base cluster directory")
+	command.Flags().StringVar(&repoRevision, "repo-revision", "main", "the git revision for cluster template directory")
+	command.Flags().StringVar(&repoPath, "repo-path", "", "the git repository path for cluster template directory")
 	command.Flags().IntVar(&casMin, "cas-min", 1, "set minimum number of nodes for capi-cluster autoscaler, for MachineDeployment based clusters")
 	command.Flags().IntVar(&casMax, "cas-max", 9, "set maximum number of nodes for capi-cluster autoscaler, for MachineDeployment based clusters")
 	command.MarkFlagsMutuallyExclusive("repo-url", "repo-alias")

--- a/cmd/basecluster/validate.go
+++ b/cmd/basecluster/validate.go
@@ -15,8 +15,8 @@ func validateBaseClusterCommand() *cobra.Command {
 	*/
 	command := &cobra.Command{
 		Use:   "validate <filename> [flags]",
-		Short: "validate base cluster file",
-		Long:  "validate base cluster file",
+		Short: "validate cluster template files",
+		Long:  "validate cluster template files",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			/*

--- a/cmd/basecluster/validategit.go
+++ b/cmd/basecluster/validategit.go
@@ -19,8 +19,8 @@ func validateGitBaseClusterCommand() *cobra.Command {
 	var repoRevision string
 	command := &cobra.Command{
 		Use:   "validategit --repo-url repoUrl [--repo-revision revision] [--repo-path path]",
-		Short: "validate base cluster directory in git",
-		Long:  "validate base cluster directory in git",
+		Short: "validate cluster template directory in git",
+		Long:  "validate cluster template directory in git",
 		RunE: func(c *cobra.Command, args []string) error {
 			if repoUrl == "" {
 				var err error
@@ -47,10 +47,10 @@ func validateGitBaseClusterCommand() *cobra.Command {
 	}
 	clientConfig = cli.AddKubectlFlagsToCmd(command)
 	command.Flags().StringVar(&argocdNs, "argocd-ns", "argocd", "the argocd namespace")
-	command.Flags().StringVar(&repoUrl, "repo-url", "", "the git repository url for base cluster directory")
+	command.Flags().StringVar(&repoUrl, "repo-url", "", "the git repository url for cluster template directory")
 	command.Flags().StringVar(&repoAlias, "repo-alias", gitrepo.RepoDefaultCtx, "git repository alias to use")
-	command.Flags().StringVar(&repoRevision, "repo-revision", "main", "the git revision for base cluster directory")
-	command.Flags().StringVar(&repoPath, "repo-path", "", "the git repository path for base cluster directory")
+	command.Flags().StringVar(&repoRevision, "repo-revision", "main", "the git revision for cluster template directory")
+	command.Flags().StringVar(&repoPath, "repo-path", "", "the git repository path for cluster template directory")
 	command.MarkFlagsMutuallyExclusive("repo-url", "repo-alias")
 	return command
 }

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -80,7 +80,7 @@ func createClusterCommand() *cobra.Command {
 			baseClusterName, err := bcl.ValidateGitDir(creds,
 				clusterRepoUrl, clusterRepoRevision, clusterRepoPath)
 			if err != nil {
-				return fmt.Errorf("failed to validate base cluster: %s", err)
+				return fmt.Errorf("failed to validate cluster template: %s", err)
 			}
 			var prof *arlonv1.Profile
 			if profileName != "" {

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -46,7 +46,7 @@ func listClusters(clientConfig clientcmd.ClientConfig, argocdNs string) error {
 
 func printClusterTable(clist []cluster.Cluster) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintf(w, "NAME\tEXTERNAL\tBASECLUSTER\tCLUSTERSPEC\tPROFILE\tAPPPROFILES\n")
+	_, _ = fmt.Fprintf(w, "NAME\tEXTERNAL\tCLUSTERTEMPLATE\tCLUSTERSPEC\tPROFILE\tAPPPROFILES\n")
 	for _, c := range clist {
 		var baseClusterName string
 		if c.BaseCluster != nil {

--- a/cmd/initialize/init.go
+++ b/cmd/initialize/init.go
@@ -285,7 +285,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&noConfirm, "no-confirm", "y", false, "this flag disables the prompts for argocd and arlon installation on the management cluster")
-	cmd.Flags().BoolVarP(&addExamples, "examples", "e", false, "this flag adds example base cluster manifests")
+	cmd.Flags().BoolVarP(&addExamples, "examples", "e", false, "this flag adds example cluster template manifests")
 	cmd.Flags().StringVar(&gitUser, "username", "", "the git username for the workspace repository")
 	cmd.Flags().StringVar(&password, "password", "", "the password for git user")
 	cmd.Flags().StringVar(&repoUrl, "repoUrl", "", "URL for the workspace repository")

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,8 @@ coverage:
     patch:
       default:
         informational: true
+comment:
+  layout: diff
 
 
 # When modifying this file, please validate using

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,8 +6,8 @@ coverage:
     patch:
       default:
         informational: true
-comment:
-  layout: diff
+github_checks:
+  annotations: false
 
 
 # When modifying this file, please validate using

--- a/docs/gen2_Tutorial.md
+++ b/docs/gen2_Tutorial.md
@@ -378,7 +378,7 @@ arlon cluster create --cluster-name <clusterName> --repo-alias prod --repo-path 
 ## gen2 cluster creation with overrides
 
 We call the concept of constructing various clusters with patches from the same base manifest as cluster overrides.
-The cluster overrides feature is built on top of the existing base cluster design. So, A user can create a cluster from the base manifest using the same command as in the above step(gen2 cluster creation).
+The cluster overrides feature is built on top of the existing cluster template design. So, A user can create a cluster from the base manifest using the same command as in the above step(gen2 cluster creation).
 Now, to create a cluster with overrides in the base manifest, a user should have the corresponding patch files in a single yaml file in local. Here is an example of a patch file where we want to override replicas count to 2 and change the sshkeyname:
 
 ```shell

--- a/pkg/basecluster/errors.go
+++ b/pkg/basecluster/errors.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	ErrMultipleManifests    = errors.New("multiple manifests found")
-	ErrNoManifest           = errors.New("failed to find base cluster manifest file")
+	ErrNoManifest           = errors.New("failed to find cluster template manifest file")
 	ErrNoKustomizationYaml  = errors.New("kustomization.yaml is missing")
 	ErrNoConfigurationsYaml = errors.New("configurations.yaml is missing")
 	ErrMultipleClusters     = errors.New("there are 2 or more clusters")

--- a/pkg/basecluster/prepare.go
+++ b/pkg/basecluster/prepare.go
@@ -131,7 +131,7 @@ func PrepareGitDir(
 		return "", false, fmt.Errorf("failed to prepare directory: %s", err)
 	}
 	changed, err = gitutils.CommitChanges(tmpDir, wt,
-		"prepare base cluster files for "+path.Join(repoPath, manifestFileName))
+		"prepare cluster template files for "+path.Join(repoPath, manifestFileName))
 	if err != nil {
 		err = fmt.Errorf("failed to commit changes: %s", err)
 		return
@@ -154,7 +154,7 @@ func PrepareGitDir(
 
 // -----------------------------------------------------------------------------
 
-// Prepares specified directory to use as base cluster, and returns the
+// prepareDir prepares specified directory to use as cluster template, and returns the
 // name of the cluster resource. dirRelPath is the name of the directory
 // relative to the file system, and actualFsRootDir is the actual path
 // of the file system's root directory on the native file system.
@@ -193,7 +193,7 @@ func prepareDir(
 		manifestFileName = info.Name()
 	}
 	if manifestFileName == "" {
-		err = fmt.Errorf("failed to find base cluster manifest file")
+		err = fmt.Errorf("failed to find cluster template manifest file")
 		return
 	}
 	manifestRelPath := path.Join(dirRelPath, manifestFileName)

--- a/pkg/basecluster/validate.go
+++ b/pkg/basecluster/validate.go
@@ -68,8 +68,8 @@ func ValidateGitDir(
 
 // -----------------------------------------------------------------------------
 
-// Given a list of file entries from a directory, validates whether
-// conditions are met for using the directory as a base cluster.
+// validateDir when given a list of file entries from a directory, validates whether
+// conditions are met for using the directory as a cluster template directory.
 func validateDir(dirPath string, infos []os.FileInfo) (clusterName string, err error) {
 	var kustomizationFound bool
 	var configurationsFound bool

--- a/pkg/cluster/get.go
+++ b/pkg/cluster/get.go
@@ -90,8 +90,8 @@ func (c *Cluster) String() string {
 	if c.IsExternal {
 		s = s + ", Type: external"
 	} else if c.BaseCluster != nil {
-		s = s + ", Type: next-gen, Base Cluster Repo Url: " + c.BaseCluster.RepoUrl +
-			", Base Cluster Repo Path: " + c.BaseCluster.RepoPath
+		s = s + ", Type: next-gen, Cluster template Repo Url: " + c.BaseCluster.RepoUrl +
+			", Cluster template Repo Path: " + c.BaseCluster.RepoPath
 	} else {
 		s = s + ", Type: previous gen, Cluster Spec: " + c.ClusterSpecName
 	}

--- a/testing/README.md
+++ b/testing/README.md
@@ -10,7 +10,7 @@
 - run: `testing/ubuntu_testbed_prereqs.sh` (this step can be run in parallel in a separate window, a few seconds after starting the previous step)
 - log out and log back in to ensure you have the right permissions to run docker (run `docker ps` to verify). Alternatively, run `newgrp docker`, which starts a new shell.
 - create testbed: `testing/ensure_testbed.sh`
-- optionally run E2E smoke test: `testing/test_basecluster_deploy_with_capd.sh`. This registers a base cluster that uses CAPD, and deploys a workload cluster.
+- optionally run E2E smoke test: `testing/test_basecluster_deploy_with_capd.sh`. This registers a cluster template manifest that uses CAPD, and deploys a workload cluster.
 - optional cleanup: `arlon cluster delete capd-1`.
 - Unfortunately, there is a bug in CAPD provider that won't clean up some resources. To clean up manually:
   - get a list of remaining dockermachines: `kubectl -n capd-1 get dockermachine`

--- a/testing/README.md
+++ b/testing/README.md
@@ -10,7 +10,7 @@
 - run: `testing/ubuntu_testbed_prereqs.sh` (this step can be run in parallel in a separate window, a few seconds after starting the previous step)
 - log out and log back in to ensure you have the right permissions to run docker (run `docker ps` to verify). Alternatively, run `newgrp docker`, which starts a new shell.
 - create testbed: `testing/ensure_testbed.sh`
-- optionally run E2E smoke test: `testing/test_basecluster_deploy_with_capd.sh`. This registers a cluster template manifest that uses CAPD, and deploys a workload cluster.
+- optionally run E2E smoke test: `testing/test_basecluster_deploy_with_capd.sh`. This registers a cluster template manifest that uses CAPD(CAPI provider for Docker), and deploys a workload cluster.
 - optional cleanup: `arlon cluster delete capd-1`.
 - Unfortunately, there is a bug in CAPD provider that won't clean up some resources. To clean up manually:
   - get a list of remaining dockermachines: `kubectl -n capd-1 get dockermachine`


### PR DESCRIPTION
https://docs.codecov.com/docs/github-checks
This doc details GitHub annotations, we can choose to not disable them and use the 'a' key to toggle it on the fly.