### PR TITLE
[docs] [v0.10] restructure concepts.md to prioritize gen2 profiles and clusters

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,84 +10,26 @@ This Kubernetes cluster hosts the following components:
 
 The Arlon state and controllers reside in the arlon namespace.
 
-## Configuration bundle
+## Workload Cluster
 
-A configuration bundle (or just "bundle") is grouping of data files that
-produce a set of Kubernetes manifests via a *tool*. This closely follows ArgoCD's
-definition of *tool types*. Consequently, the list of supported bundle
-types mirrors ArgoCD's supported set of manifest-producing tools.
-Each bundle is defined using a Kubernetes ConfigMap resource in the arlon namespace.
-
-### Static bundle
-
-A static bundle embeds the manifest's YAML data itself ("static bundle").
-A cluster consuming a static bundle will always have a snapshot copy of
-the bundle at the time the cluster was created, and is not affected by subsequent
-changes to the bundle's manifest data.
-
-### Dynamic bundle
-
-A dynamic bundle contains a reference to the manifest data stored in git.
-A dynamic bundle is distinguished
-by having these fields set to non-empty values:
-
-- git URL of the repo
-- Directory path within the repo
-
-The git URL must be registered in ArgoCD as a valid repository. The content of
-the specified directory can contain manifests in any of the *tool* formats supported
-by ArgoCD, including plain YAML, Helm and Kustomize.
-
-When the user updates a dynamic bundle in git, all clusters consuming that bundle
-(through a profile specified at cluster creation time) will acquire the change.
-
-### Other properties
-
-A bundle can also have a comma-separated list of tags, and a description.
-Tags can be useful for classifying bundles, for e.g. by type
-("addon", "cni", "rbac", "app").
-
-## Profile
-
-A profile expresses a desired configuration for a Kubernetes cluster.
-It is just a set of references to bundles (static, dynamic, or a combination).
-A profile can be static or dynamic.
-
-### Static profile
-
-When a cluster consumes a static profile
-at creation time, the set of bundles for the cluster is fixed at that time
-and does not change over time even when the static bundle is updated.
-(Note: the contents of some of those bundles referenced by the static
-profile may however change over time if they are dynamic).
-A static profile is stored as an item
-in the Arlon database (specifically, as a CR in the Management Cluster).
-
-### Dynamic profile
-
-A dynamic profile, on the other hand, has two components: the specification
-stored in the Arlon database, and a *compiled* component living in the workspace
-repository at a path specified by the user.
-(Note: this repository is usually the workspace repo, but it technically doesn't
-have to be, as long as it's a valid repo registered in ArgoCD)
-The compiled component is essentially a
-Helm chart of multiple ArgoCD app resources, each one pointing to a bundle.
-Arlon automatically creates and maintains the compiled component.
-When a user updates the composition of a dynamic profile, meaning redefines its
-bundle set, the Arlon library updates the compiled component to point to the
-bundles specified in the new set. Any cluster
-consuming that dynamic profile will be affected by the change, meaning it may lose
-or acquire new bundles in real time.
-
-## Cluster
-
-An Arlon cluster, also known as workload cluster, is a Kubernetes cluster
+An Arlon workload cluster is a Kubernetes cluster
 that Arlon creates and manages via a git directory structure stored in
 the workspace repository.
 
 The new way of provisioning workload clusters in Arlon since v0.9 is gen2 clusters using *cluster template* that replace gen1 clusters using *cluster spec*
 The most significant change in gen2 clusters is the *Cluster Template* construct, which replaces the older cluster spec from gen1 clusters.
 To distinguish them from the older gen1 clusters, the ones deployed from a cluster template are called next-gen clusters or gen2 clusters.
+
+## Cluster Template (gen2 cluster)
+
+A cluster template is a base cluster manifest that can be "cloned" to produce
+one or more identical or similar workload clusters.
+To create a cluster template, you first compose a manifest containing one or more
+declarative resources that define the kind and shape of cluster that you desire.
+You then store the manifest in its own directoy somewhere in git.
+You then instruct Arlon to "prep" the directory to promote it to cluster template.
+To know more about cluster template for Arlon gen2 clusters including the difference
+with cluster spec and the process to create gen2 clusters; read the document [cluster template](./clustertemplate.md)
 
 ## Cluster spec (gen1 clusters : deprecated since 0.10)
 
@@ -101,6 +43,37 @@ They currently include:
 - The initial (worker) node count
 - The Kubernetes version
 
-## Cluster Template
+## Application (App)
 
-To know more about cluster template for Arlon gen2 clusters including the difference with cluster spec and the process to create gen2 clusters; read the document [cluster template](./clustertemplate.md)
+An Arlon Application (or "App" for short) defines a source of Kubernetes
+manifests that can be applied/deployed to a workload cluster. It can
+take the form of raw YAML files, a Helm chart, or a Kustomize directory.
+The source resides in a git repository.
+Arlon represents an App as a specialized ArgoCD ApplicationSet resource.
+An App is not limited traditional "applications" and can refer to any set of
+deployable resources, for e.g. Kubernetes RBAC rules or other types
+of configurations.
+For more details about Apps, refer to [AppProfiles article](./appprofiles.md)
+
+## Application Profile (AppProfile)
+
+An AppProfile is simply a set of App names referring to Arlon Apps.
+You use AppProfile resources to define common groupings of apps, for example
+"monitoring-stack", or "security-policies-1".
+It is perfectly legal for multiple AppProfiles to refer to some common App names,
+meaning they can overlap.
+For more details about AppProfiles, refer to [AppProfiles article](./appprofiles.md)
+
+## Deploying apps to workload clusters
+
+You deploy apps to workload clusters by annotating a workload cluster
+with the desired AppProfile(s). The union of all Apps referenced by those
+AppProfiles is deployed to the cluster.
+For more details about annotating/targeting clusters,
+refer to [AppProfiles article](./appprofiles.md)
+
+## Gen1 Profiles
+
+Apps and AppProfiles are a newer version ("gen2") of Arlon profiles.
+There is an older version called "gen1", which is composed of the concepts
+of Bundles and Profiles. For more details, see [Bundles and Profiles](./gen1_profiles.md)

--- a/docs/gen1_profiles.md
+++ b/docs/gen1_profiles.md
@@ -1,0 +1,71 @@
+# Bundles and Profiles - Concepts
+
+## Configuration bundle
+
+A configuration bundle (or just "bundle") is grouping of data files that
+produce a set of Kubernetes manifests via a *tool*. This closely follows ArgoCD's
+definition of *tool types*. Consequently, the list of supported bundle
+types mirrors ArgoCD's supported set of manifest-producing tools.
+Each bundle is defined using a Kubernetes ConfigMap resource in the arlon namespace.
+
+### Static bundle
+
+A static bundle embeds the manifest's YAML data itself ("static bundle").
+A cluster consuming a static bundle will always have a snapshot copy of
+the bundle at the time the cluster was created, and is not affected by subsequent
+changes to the bundle's manifest data.
+
+### Dynamic bundle
+
+A dynamic bundle contains a reference to the manifest data stored in git.
+A dynamic bundle is distinguished
+by having these fields set to non-empty values:
+
+- git URL of the repo
+- Directory path within the repo
+
+The git URL must be registered in ArgoCD as a valid repository. The content of
+the specified directory can contain manifests in any of the *tool* formats supported
+by ArgoCD, including plain YAML, Helm and Kustomize.
+
+When the user updates a dynamic bundle in git, all clusters consuming that bundle
+(through a profile specified at cluster creation time) will acquire the change.
+
+### Other properties
+
+A bundle can also have a comma-separated list of tags, and a description.
+Tags can be useful for classifying bundles, for e.g. by type
+("addon", "cni", "rbac", "app").
+
+## Profile
+
+A profile expresses a desired configuration for a Kubernetes cluster.
+It is just a set of references to bundles (static, dynamic, or a combination).
+A profile can be static or dynamic.
+
+### Static profile
+
+When a cluster consumes a static profile
+at creation time, the set of bundles for the cluster is fixed at that time
+and does not change over time even when the static bundle is updated.
+(Note: the contents of some of those bundles referenced by the static
+profile may however change over time if they are dynamic).
+A static profile is stored as an item
+in the Arlon database (specifically, as a CR in the Management Cluster).
+
+### Dynamic profile
+
+A dynamic profile, on the other hand, has two components: the specification
+stored in the Arlon database, and a *compiled* component living in the workspace
+repository at a path specified by the user.
+(Note: this repository is usually the workspace repo, but it technically doesn't
+have to be, as long as it's a valid repo registered in ArgoCD)
+The compiled component is essentially a
+Helm chart of multiple ArgoCD app resources, each one pointing to a bundle.
+Arlon automatically creates and maintains the compiled component.
+When a user updates the composition of a dynamic profile, meaning redefines its
+bundle set, the Arlon library updates the compiled component to point to the
+bundles specified in the new set. Any cluster
+consuming that dynamic profile will be affected by the change, meaning it may lose
+or acquire new bundles in real time.
+


### PR DESCRIPTION
Backport to v0.10 from main branch

* restructure concepts.md to prioritize gen2 profiles and add details about cluster templates

Aha! Link: https://pf9.aha.io/features/ARLON-375