### PR TITLE
[docs infra] Minor fix in docs/requirements.txt with mkdocs-material update

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs==1.4.2
 mkdocs-material==9.0.5
-pymdown-extensions==9.9
+pymdown-extensions>=9.9.1
 mkdocs_pymdownx_material_extras==2.3.1
 mkdocs-minify-plugin==0.6.2
 mike==1.1.2


### PR DESCRIPTION
Can backport to v0.10 - along with https://github.com/arlonproj/arlon/pull/433 