### PR TITLE
update to capi v1.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           skip-pkg-cache: true
-          args: --timeout=5m
+          args: --timeout=10m
   build_and_unit_test:
     environment: Build
     runs-on: ubuntu-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ before:
 builds:
   - id: 'cli'
     ldflags:
-      - -X github.com/arlonproj/arlon/cmd/install.capiCoreProvider=cluster-api:v1.3.2
+      - -X github.com/arlonproj/arlon/cmd/install.capiCoreProvider=cluster-api:v1.3.3
       - -X github.com/arlonproj/arlon/cmd/initialize.argocdGitTag=release-2.5
       - -X github.com/arlonproj/arlon/cmd/version.cliVersion=0.11.0
       - -w

--- a/capirc
+++ b/capirc
@@ -1,1 +1,1 @@
-cluster-api:v1.3.2
+cluster-api:v1.3.3


### PR DESCRIPTION
The dependabot PR updates capi to 1.3.3, but leaves out the version in capirc and .goreleaser.yaml. This PR resolves it